### PR TITLE
Notify My Android Fixes

### DIFF
--- a/couchpotato/core/notifications/notifymyandroid/main.py
+++ b/couchpotato/core/notifications/notifymyandroid/main.py
@@ -15,7 +15,11 @@ class NotifyMyAndroid(Notification):
         nma.addkey(keys)
         nma.developerkey(self.conf('dev_key'))
 
-        response = nma.push(self.app_name, 'CouchPotato', message, priority = self.priority, batch_mode = len(keys) > 1)
+        # hacky fix for the event type 
+        # as it seems to be part of the message now
+        self.event = message.split(' ')[0]
+
+        response = nma.push(self.default_title, self.event , message, self.conf('priority'), batch_mode = len(keys) > 1)
 
         for key in keys:
             if not response[str(key)]['code'] == u'200':


### PR DESCRIPTION
fixes an error preventing the notifications from sending. application name is sent correctly, the event is hacked from the message and the priority is pulled from the config (but doesn't seems to make any difference when changed)
