### PR TITLE
prefix_free.js throws an exception in Chrome when a data: URI is used for a stylesheet

### DIFF
--- a/couchpotato/static/scripts/library/prefix_free.js
+++ b/couchpotato/static/scripts/library/prefix_free.js
@@ -13,8 +13,8 @@ if(!window.addEventListener) {
 var self = window.StyleFix = {
 	link: function(link) {
 		try {
-			// Ignore stylesheets with data-noprefix attribute as well as alternate stylesheets
-			if(link.rel !== 'stylesheet' || link.hasAttribute('data-noprefix')) {
+			// Ignore stylesheets with data-noprefix attribute as well as alternate stylesheets and data URIs
+			if(link.rel !== 'stylesheet' || link.hasAttribute('data-noprefix') || link.href.substr(0,5) == 'data:') {
 				return;
 			}
 		}


### PR DESCRIPTION
Since nothing useful can be done with a data: URI via XMLHTTPRequest anyway, this commit makes sure that the data: URI stylesheet in question is simply skipped.
