### PR TITLE
Fix for unhandled exception in library scanner.

### DIFF
--- a/couchpotato/core/plugins/scanner/main.py
+++ b/couchpotato/core/plugins/scanner/main.py
@@ -474,7 +474,9 @@ class Scanner(Plugin):
                 if len(identifier) > 2:
                     try: filename = list(group['files'].get('movie'))[0]
                     except: filename = None
-                    movie = fireEvent('movie.search', q = '%(name)s %(year)s' % self.getReleaseNameYear(identifier, file_name = filename), merge = True, limit = 1)
+                    mdata = self.getReleaseNameYear(identifier, file_name = filename)
+                    if 'name' in mdata:
+                        movie = fireEvent('movie.search', q = '%(name)s %(year)s' % self.getReleaseNameYear(identifier, file_name = filename), merge = True, limit = 1)
 
                     if len(movie) > 0:
                         imdb_id = movie[0]['imdb']


### PR DESCRIPTION
21:35:29 ERROR [   couchpotato.core.event] Error in event "scanner.folder", that wasn't caught: Traceback (most recent call last):
  File "/home/media/CouchPotatoServer/couchpotato/core/event.py", line 12, in runHandler
    return handler(_args, *_kwargs)
  File "/home/media/CouchPotatoServer/couchpotato/core/plugins/scanner/main.py", line 117, in scanFolderToLibrary
    groups = self.scan(folder = folder)
  File "/home/media/CouchPotatoServer/couchpotato/core/plugins/scanner/main.py", line 322, in scan
    group['library'] = self.determineMovie(group)
  File "/home/media/CouchPotatoServer/couchpotato/core/plugins/scanner/main.py", line 477, in determineMovie
    movie = fireEvent('movie.search', q = '%(name)s %(year)s' % self.getReleaseNameYear(identifier, file_name = filename), merge = True, limit = 1)
KeyError: 'name'
