### PR TITLE
Removed group setting for init

### DIFF
--- a/init/ubuntu
+++ b/init/ubuntu
@@ -45,7 +45,7 @@ case "$1" in
   start)
         echo "Starting $DESC"
         rm -rf $PID_PATH || return 1
-        install -d --mode=0755 -o $RUN_AS -g $RUN_AS $PID_PATH || return 1
+        install -d --mode=0755 -o $RUN_AS $PID_PATH || return 1
         start-stop-daemon -d $APP_PATH -c $RUN_AS --start --background --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
         ;;
   stop)


### PR DESCRIPTION
It's not needed and causes an exit to occur if the default group is not that same as the username. In my case web services share a similar group as default but have different usernames for running the daemon.
