### PR TITLE
Added support for direct messages in twitter notifications

### DIFF
--- a/couchpotato/core/notifications/twitter/__init__.py
+++ b/couchpotato/core/notifications/twitter/__init__.py
@@ -38,6 +38,13 @@ config = [{
                     'advanced': True,
                     'description': 'Also send message when movie is snatched.',
                 },
+                {
+                    'name': 'direct_message',
+                    'default': 0,
+                    'type': 'bool',
+                    'advanced': True,
+                    'description': 'Use direct messages for the notifications (Also applies to the mentioned users).',
+                },
             ],
         }
     ],

--- a/couchpotato/core/notifications/twitter/main.py
+++ b/couchpotato/core/notifications/twitter/main.py
@@ -36,12 +36,24 @@ class Twitter(Notification):
 
         api = Api(self.consumer_key, self.consumer_secret, self.conf('access_token_key'), self.conf('access_token_secret'))
 
+        direct_message = self.conf('direct_message')
+        direct_message_users = self.conf('screen_name')
+        
         mention = self.conf('mention')
         if mention:
-            message = '%s @%s' % (message, mention.lstrip('@'))
+            if direct_message:
+                direct_message_users = '%s %s' % (direct_message_users, mention)
+                direct_message_users = direct_message_users.replace('@',' ')
+                direct_message_users = direct_message_users.replace(',',' ')
+            else:
+                message = '%s @%s' % (message, mention.lstrip('@'))
 
         try:
-            api.PostUpdate('[%s] %s' % (self.default_title, message))
+            if direct_message:
+                for user in direct_message_users.split():
+                    api.PostDirectMessage(user, '[%s] %s' % (self.default_title, message))
+            else:
+                api.PostUpdate('[%s] %s' % (self.default_title, message))
         except Exception, e:
             log.error('Error sending tweet: %s' % e)
             return False


### PR DESCRIPTION
I have added support for the use of direct messages over twitter instead of the publicly visible tweets. I highly doubt that my followers are in any way interested which movies my CouchPotatoServer snatched or downloaded :)
The commit adds an advanced option checkbox to use direct messages and will by default be off to keep the current way of working. When checked, it will send a direct message to the user represented by the 'Screen name' instead of a tweet. When a 'Mention' is filled in, it will replace all '@' and ',' occurrences by spaces and also send a direct message to each mentioned user found by splitting the resulting string on whitespaces.

Note: while I am an experienced Java developer, I am new to Python and the use of github. I hope I offered my contribution in a correct manner and that you may find it useful.
