### PR TITLE
Handle permission error in shutil.move for *nix systems during the renam...

### DIFF
--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -12,6 +12,7 @@ import os
 import re
 import shutil
 import traceback
+import errno
 
 log = CPLog(__name__)
 
@@ -426,6 +427,14 @@ class Renamer(Plugin):
                 os.chmod(dest, Env.getPermission('file'))
             except:
                 log.error('Failed setting permissions for file: %s, %s', (dest, traceback.format_exc(1)))
+
+        except OSError, err:
+            # Copying from a filesystem with octal permission to an NTFS file system causes a permission error.  In this case ignore it.
+            if not hasattr(os, 'chmod') or err.errno != errno.EPERM:
+                raise
+            else:
+                if os.path.exists(dest):
+                    os.unlink(old)
 
         except:
             log.error('Couldn\'t move file "%s" to "%s": %s', (old, dest, traceback.format_exc()))


### PR DESCRIPTION
...e plugin.

shutil.move automatically calls shutil.copystat after moving a file.  On a *nix system copystat tries to update file permissions of the new file.  If the destination has an NTFS file system the chmod will fail with a simple permission error.  This commit checks for this specific condition and if the destination file exists supresses the error and deletes the original file.
