### PR TITLE
Add 'Renamer Scan' item to manage menu

### DIFF
--- a/couchpotato/static/scripts/page/manage.js
+++ b/couchpotato/static/scripts/page/manage.js
@@ -25,11 +25,11 @@ Page.Manage = new Class({
 				}
 			});
 
-			self.refresh_quick = new Element('a', {
+			self.renamer_scan = new Element('a', {
 				'title': 'Force the renamer to scan your downloads folder for new movies',
 				'text': 'Renamer Scan',
 				'events':{
-					'click': self.renamer_scan.bind(self)
+					'click': self.scan.bind(self)
 				}
 			});
 
@@ -55,7 +55,7 @@ Page.Manage = new Class({
 
 	},
 
-	renamer_scan: function(){
+	scan: function(){
 		var self = this;
 
 		Api.request('renamer.scan')


### PR DESCRIPTION
![Renamer Scan](http://puu.sh/XGbQ)

This allows the user to trigger the Renamer Scan API call easily from the web interface.

As far as I could see there was no other way to call this API method fromt he web interface and I wanted this feature to force processing on items added to the watch directory.
