### PR TITLE
Add Permission Fix after Renaming for Windows users

### DIFF
--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -431,6 +431,7 @@ class Renamer(Plugin):
 
             try:
                 os.chmod(dest, Env.getPermission('file'))
+                os.popen('icacls "' + dest + '"* /reset /T')
             except:
                 log.error('Failed setting permissions for file: %s, %s', (dest, traceback.format_exc(1)))
 


### PR DESCRIPTION
RuudBurger: Please consider:

Unix CouchPotato users benefit from a customizable CHMOD after renaming (moving).

Windows users have no such luck, and this causes problems for those whose destination folders are shared (on the network or with another user on the same machine).

For example, if your usenet downloader downloads to folder A (which is private), but CouchPotato moves the movie to folder B (which is shared), the movie will remain private while in the shared folder and will NOT be shared.

But I committed a hacky fix!

~~I made a pull request but you or someone would still _need to make it play nicely with UNIX users_. Also maybe a checkbox in settings ("Inherit permissions from destination folder?"). But I hope you consider including this in near releases!~~
_Scroll down for commit that plays nice_

Related forum thread: http://couchpota.to/forum/showthread.php?tid=623
