### PR TITLE
Fix for downloading torrents via torrent cache sources

### DIFF
--- a/couchpotato/core/downloaders/base.py
+++ b/couchpotato/core/downloaders/base.py
@@ -16,9 +16,9 @@ class Downloader(Plugin):
     type = []
 
     torrent_sources = [
-        'http://torrage.com/torrent/%s.torrent',
-        'http://torrage.ws/torrent/%s.torrent',
-        'http://torcache.net/torrent/%s.torrent',
+        'http://torrage.com/torrent/',
+        'http://torrage.ws/torrent/',
+        'http://torcache.net/torrent/',
     ]
 
     def __init__(self):
@@ -56,7 +56,7 @@ class Downloader(Plugin):
         return is_correct
 
     def magnetToTorrent(self, magnet_link):
-        torrent_hash = re.findall('urn:btih:([\w]{32,40})', magnet_link)[0]
+        torrent_hash = re.findall('urn:btih:([\w]{32,40})', magnet_link)[0].upper()
 
         # Convert base 32 to hex
         if len(torrent_hash) == 32:
@@ -67,8 +67,12 @@ class Downloader(Plugin):
 
         for source in sources:
             try:
-                filedata = self.urlopen(source % torrent_hash, headers = {'Referer': ''}, show_error = False)
+                url = '%s%s.torrent' % (source, torrent_hash)
+                filedata = self.urlopen(url, headers = {'Referer': ''}, show_error = False)
                 if 'torcache' in filedata and 'file not found' in filedata.lower():
+                    continue
+                if not filedata:
+                    log.debug('Could not retrieve torrent hash %s from torrent source: %s', (torrent_hash, source))
                     continue
 
                 return filedata


### PR DESCRIPTION
This fix will properly format the URL for the torrent cache sites to put the hash as uppercase instead of lowercase which was causing issues retrieving the torrent file from the source site because the files when requested are case-sensitive.

Also for debugging purposes I noticed that in the logs it would mention the torrent source as %s.torrent which I've corrected by changing the way the URL is built before sent via the urlopen function with the torrent info_hash variable.

This fix has been tested on my end and works perfectly so feel free to test on your end as well.

Thanks.
