### PR TITLE
fix audio scoring

### DIFF
--- a/couchpotato/core/plugins/score/scores.py
+++ b/couchpotato/core/plugins/score/scores.py
@@ -10,7 +10,7 @@ name_scores = [
     # Video
     'x264:1', 'h264:1',
     # Audio
-    'DTS:4', 'AC3:2',
+    'dts:4', 'ac3:2',
     # Quality
     '720p:10', '1080p:10', 'bluray:10', 'dvd:1', 'dvdrip:1', 'brrip:1', 'bdrip:1', 'bd50:1', 'bd25:1',
     # Language / Subs


### PR DESCRIPTION
The elements of name_scores are compared to a lower-cased version of the release name so they need to be also lower cased.
