### PR TITLE
Readme modification to make clear the default port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Windows, see [the CP forum](http://couchpota.to/forum/showthread.php?tid=14) for
 * Open up `Git Bash` (or CMD) and go to the folder you want to install CP. Something like Program Files.
 * Run `git clone https://github.com/RuudBurger/CouchPotatoServer.git`.
 * You can now start CP via `CouchPotatoServer\CouchPotato.py` to start
-* Open your browser and go to: 'http://localhost:5050/'
+* Open your browser and go to: `http://localhost:5050/`
 
 OSx:
 
@@ -27,7 +27,7 @@ OSx:
 * Go to your App folder `cd /Applications`
 * Run `git clone https://github.com/RuudBurger/CouchPotatoServer.git`
 * Then do `python CouchPotatoServer/CouchPotato.py`
-* Open your browser and go to: 'http://localhost:5050/'
+* Open your browser and go to: `http://localhost:5050/`
 
 Linux (ubuntu / debian):
 
@@ -39,4 +39,4 @@ Linux (ubuntu / debian):
 * Change the paths inside the init script. `sudo nano /etc/init.d/couchpotato`
 * Make it executable. `sudo chmod +x /etc/init.d/couchpotato`
 * Add it to defaults. `sudo update-rc.d couchpotato defaults`
-* Open your browser and go to: 'http://localhost:5050/'
+* Open your browser and go to: `http://localhost:5050/`


### PR DESCRIPTION
First of all , excellent piece of software. Considering to start helping with the development.
Now, the reason of the commit:
If you've never installed CP before you'll notice that there's no information at all of the default http port to see the web ui.
One friend found that info after 10 minutes on a random site doing wacky google searches.
If your Python skills are not that good to read the code and spot it , you're probably desisting of CP
That can be avoided and all newcomers can see the port right away if that data is added to the readme.
Best,
bruno.
