### PR TITLE
Added mapping of audio codecs from enzyme

### DIFF
--- a/couchpotato/core/plugins/scanner/main.py
+++ b/couchpotato/core/plugins/scanner/main.py
@@ -422,7 +422,7 @@ class Scanner(Plugin):
 
         try:
             p = enzyme.parse(filename)
-            if p.video[0].codec == 'AVC1'
+            if p.video[0].codec == 'AVC1':
                 p.video[0].codec = 'h264'
             p.audio[0].codec = self.codecmap[p.audio[0].codec]
             return {


### PR DESCRIPTION
addresses the audio tag issue in #271 as well as several closed issues that are referenced in it and several posts over on the forums.

I am almost certain there is a neater way using some form of structure to compare the decimal value to the name, but this method makes sense to me... I was probably a little over-cautious in doing a str() comparison with the returned result from enzyme, I believe this is already a string, but figured it was safer this way, and also used the a_dec array as string values.

I can't see an easy way to address the group tag or the source tag issue as the file name is not presented as "group:xyz" etc and there are too many groups and sources to try and index.... Perhaps by parsing the data in the original .nfo this may be possible... but I put that in the "I need to learn more python" category ;)
