### PR TITLE
Add Filmweb support to userscript

### DIFF
--- a/couchpotato/core/providers/userscript/filmweb/__init__.py
+++ b/couchpotato/core/providers/userscript/filmweb/__init__.py
@@ -1,0 +1,6 @@
+from .main import Filmweb
+
+def start():
+    return Filmweb()
+
+config = []

--- a/couchpotato/core/providers/userscript/filmweb/main.py
+++ b/couchpotato/core/providers/userscript/filmweb/main.py
@@ -1,0 +1,28 @@
+from couchpotato.core.providers.userscript.base import UserscriptBase
+import re
+
+
+class Filmweb(UserscriptBase):
+
+    includes = ['http://www.filmweb.pl/*']
+
+    def getMovie(self, url):
+
+        cookie = {'Cookie': 'welcomeScreen=welcome_screen'}
+
+        try:
+            data = self.urlopen(url, headers = cookie)
+        except:
+            return
+
+        name = re.search("<h2.*?class=\"text-large caption\">(?P<name>[^<]+)</h2>", data)
+
+        if name is None:
+            name = re.search("<a.*?property=\"v:name\".*?>(?P<name>[^<]+)</a>", data)
+
+        name = name.group('name').decode('string_escape')
+
+        year = re.search("<span.*?id=filmYear.*?>\((?P<year>[^\)]+)\).*?</span>", data)
+        year = year.group('year')
+
+        return self.search(name, year)


### PR DESCRIPTION
Hey,

First, thanks for a great piece of software.

I thought I'd add Filmweb support to the userscript as this is the site I use most often for movie information. **BIG FAT WARNING**: I've never coded anything in Python before so you really want to check my contribution for any bad coding practices etc. The code is based on the Apple Trailers part of userscript. It works for me, yet YMMV :)

I used `self.urlopen()` instead of `self.getUrl()` as the latter won't allow me to pass the cookie (which is needed to access anything else than the welcome screen at Filmweb) as an argument and I didn't want to mess up the rest of your code.
