### PR TITLE
Update init/fedora

### DIFF
--- a/init/fedora
+++ b/init/fedora
@@ -11,11 +11,6 @@
 # Source function library.
 . /etc/init.d/functions
 
-# Source couchpotato configuration
-if [ -f /etc/sysconfig/couchpotato ]; then
-        . /etc/sysconfig/couchpotato
-fi
-
 prog=couchpotato
 lockfile=/var/lock/subsys/$prog
 
@@ -26,6 +21,11 @@ homedir=${CP_HOME-/opt/couchpotato}
 datadir=${CP_DATA-~/.couchpotato}
 pidfile=${CP_PIDFILE-/var/run/couchpotato/couchpotato.pid}
 ##
+
+# Source couchpotato configuration
+if [ -f /etc/sysconfig/couchpotato ]; then
+        . /etc/sysconfig/couchpotato
+fi
 
 pidpath=`dirname ${pidfile}`
 options=" --daemon --pid_file=${pidfile} --data_dir=${datadir}"


### PR DESCRIPTION
The config file should be read after the defaults are set, or the options set in the config file are never used.
