### PR TITLE
Fix TPB search (new page layout on their side)

### DIFF
--- a/couchpotato/core/providers/torrent/thepiratebay/main.py
+++ b/couchpotato/core/providers/torrent/thepiratebay/main.py
@@ -89,7 +89,7 @@ class ThePirateBay(TorrentProvider):
                 soup = BeautifulSoup(data)
                 results_table = soup.find('table', attrs = {'id': 'searchResult'})
                 entries = results_table.find_all('tr')
-                for result in entries[1:]:
+                for result in entries[2:]:
                     link = result.find(href = re.compile('torrent\/\d+\/'))
                     download = result.find(href = re.compile('magnet:'))
 


### PR DESCRIPTION
This fixes the issue #1087.
Seems like TPB added a "header" to their result page, which means we have to skip it while parsing the results.
