### PR TITLE
Remove ignore words. URL too long

### DIFF
--- a/couchpotato/core/providers/nzb/nzbclub/main.py
+++ b/couchpotato/core/providers/nzb/nzbclub/main.py
@@ -29,8 +29,6 @@ class NZBClub(NZBProvider, RSS):
             return results
 
         q = '"%s %s" %s' % (simplifyString(getTitle(movie['library'])), movie['library']['year'], quality.get('identifier'))
-        for ignored in Env.setting('ignored_words', 'searcher').split(','):
-            q = '%s -%s' % (q, ignored.strip())
 
         params = {
             'q': q,


### PR DESCRIPTION
Adding the ignore words can make the URL too long and results in 401 - Unauthorized: Access is denied due to invalid credentials.
These words should still be ignored from any returned results. The potential issue is a large list of movies being returned.
