### PR TITLE
Added try: except for two common errors

### DIFF
--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -313,7 +313,10 @@ class Renamer(Plugin):
                         elif release.status_id is snatched_status.get('id'):
                             if release.quality.id is group['meta_data']['quality']['id']:
                                 log.debug('Marking release as downloaded')
-                                release.status_id = downloaded_status.get('id')
+                                try:
+                                    release.status_id = downloaded_status.get('id')
+                                except Exception, e:
+                                    log.error('Failed marking release as finished: %s %s', (e, traceback.format_exc()))
                                 db.commit()
 
                 # Remove leftover files
@@ -350,7 +353,10 @@ class Renamer(Plugin):
 
             # Delete leftover folder from older releases
             for delete_folder in delete_folders:
-                self.deleteEmptyFolder(delete_folder, show_error = False)
+                try:
+                    self.deleteEmptyFolder(delete_folder, show_error = False)
+                except Exception, e:
+                    log.error('Failed to delete folder: %s %s', (e, traceback.format_exc()))
 
             # Rename all files marked
             group['renamed_files'] = []


### PR DESCRIPTION
Should address some of the issues in #978 and #1120
Does not fix the errors, but prevents the renamer being stuck as "in progress"
Allows next instance to run.
