### PR TITLE
fixed freebsd init script

### DIFF
--- a/init/freebsd
+++ b/init/freebsd
@@ -25,6 +25,9 @@
 name="couchpotato"
 rcvar=${name}_enable
 
+# Required, for some reason, to find all our binaries when starting via service.
+PATH="/usr/bin:/usr/local/bin:$PATH"
+
 load_rc_config ${name}
 
 : ${couchpotato_enable:="NO"}


### PR DESCRIPTION
After my upgrade to freebsd 9.1 and the latest update of couchpotato, the rc script was not working anymore. I fixed this by simply adding PATH="/usr/local/bin:$PATH"
