### PR TITLE
Adding iTunes Store RSS automation provider

### DIFF
--- a/couchpotato/core/providers/automation/itunes/__init__.py
+++ b/couchpotato/core/providers/automation/itunes/__init__.py
@@ -1,0 +1,33 @@
+from .main import ITunes 
+
+def start():
+    return ITunes()
+
+config = [{
+    'name': 'itunes',
+    'groups': [
+        {
+            'tab': 'automation',
+            'name': 'itunes_automation',
+            'label': 'iTunes',
+            'description': 'From any <a href="http://itunes.apple.com/rss">iTunes</a> Store feed. Url should be the RSS link. (uses minimal requirements)',
+            'options': [
+                {
+                    'name': 'automation_enabled',
+                    'default': False,
+                    'type': 'enabler',
+                },
+                {
+                    'name': 'automation_urls_use',
+                    'label': 'Use',
+                },
+                {
+                    'name': 'automation_urls',
+                    'label': 'url',
+                    'type': 'combined',
+                    'combine': ['automation_urls_use', 'automation_urls'],
+                },
+            ],
+        },
+    ],
+}]

--- a/couchpotato/core/providers/automation/itunes/main.py
+++ b/couchpotato/core/providers/automation/itunes/main.py
@@ -1,0 +1,63 @@
+from couchpotato.core.helpers.rss import RSS
+from couchpotato.core.helpers.variable import md5, getImdb, splitString, tryInt
+from couchpotato.core.logger import CPLog
+from couchpotato.core.providers.automation.base import Automation
+import datetime
+import xml.etree.ElementTree as XMLTree
+from xml.etree.ElementTree import QName
+import traceback
+
+log = CPLog(__name__)
+
+
+class ITunes(Automation, RSS):
+
+    interval = 1800
+
+    def getIMDBids(self):
+
+        if self.isDisabled():
+            return
+
+        movies = []
+
+        enablers = [tryInt(x) for x in splitString(self.conf('automation_urls_use'))]
+        urls = splitString(self.conf('automation_urls'))
+
+        namespace = 'http://www.w3.org/2005/Atom'
+        namespaceIM = 'http://itunes.apple.com/rss'
+        
+        index = -1
+        for url in urls:
+
+            index += 1
+            if not enablers[index]:
+                continue
+
+            try:
+                cache_key = 'itunes.rss.%s' % md5(url)
+                rss_data = self.getCache(cache_key, url)
+
+                data = XMLTree.fromstring(rss_data)
+                
+                if data is not None:
+                    entry_tag = str(QName(namespace, 'entry'))
+                    rss_movies = self.getElements(data, entry_tag)
+                    
+                    for movie in rss_movies:
+                        name_tag = str(QName(namespaceIM, 'name'))
+                        name = self.getTextElement( movie, name_tag )
+                        
+                        releaseDate_tag = str(QName(namespaceIM, 'releaseDate')) 
+                        releaseDateText = self.getTextElement(movie, releaseDate_tag)
+                        year = datetime.datetime.strptime(releaseDateText, '%Y-%m-%dT00:00:00-07:00').strftime("%Y")
+                        
+                        imdb = self.search(name, year)
+                        
+                        if imdb and self.isMinimalMovie(imdb):
+                            movies.append(imdb['imdb'])
+            
+            except:
+                log.error('Failed loading iTunes rss feed: %s %s', (url, traceback.format_exc()))
+
+        return movies


### PR DESCRIPTION
The <a href="http://itunes.apple.com/rss">iTunes Store RSS Generator</a> allows you to create an RSS feed URL that reflects iTunes' top charts and new content, including <b>Top Movies</b> and <b>Top Video Rentals</b>. You can also specify Country, Genre (i.e. Comedy), and number of items to include in the results.

Similar to the IMDB watchlist automation provider, the <b>iTunes automation provider</b> allows you to configure and enable a set of iTunes generated urls to download new and popular content according to ITunes.

The iTunes automation provider respects the "Minimal movie requirements" (year/votes/ratings) to only add the items meeting those requirements. 

![Screen Shot 2012-12-31 at 5 35 21 PM](https://f.cloud.github.com/assets/1297859/37005/6b301faa-539a-11e2-8a6f-42ba8b4dd3ea.png)

For example, I have it configured to queue the following:
- Top Movies, 25 items, All Genres
- Top Video Rentals, 25 items. All Genres
- Top Video Rentals, 10 items, Comedies
- Minimum requirements: Year: 2010, Votes: 1, Ratings: 1
