### PR TITLE
Added e-mail notifier

### DIFF
--- a/couchpotato/core/notifications/email/__init__.py
+++ b/couchpotato/core/notifications/email/__init__.py
@@ -1,0 +1,60 @@
+from .main import Email
+
+def start():
+    return Email()
+
+config = [{
+    'name': 'email',
+    'groups': [
+        {
+            'tab': 'notifications',
+            'name': 'email',
+            'options': [
+                {
+                    'name': 'enabled',
+                    'default': 0,
+                    'type': 'enabler',
+                },
+                {
+                    'name': 'from',
+                    'label': 'Send e-mail from',
+                },
+                {
+                    'name': 'to',
+                    'label': 'Send e-mail to',
+                },
+                {
+                    'name': 'subject',
+                    'label': 'Subject',
+                    'default': 'Couch Potato report',
+                },
+                {
+                    'name': 'smtp_server',
+                    'label': 'SMTP server',
+                },
+                {
+                    'name': 'ssl',
+                    'label': 'Enable SSL',
+                    'default': 0,
+                    'type': 'bool',
+                },
+                {
+                    'name': 'smtp_user',
+                    'label': 'SMTP user',
+                },
+                {
+                    'name': 'smtp_pass',
+                    'label': 'SMTP password',
+                    'type': 'password',
+                },
+                {
+                    'name': 'on_snatch',
+                    'default': 0,
+                    'type': 'bool',
+                    'advanced': True,
+                    'description': 'Also send message when movie is snatched.',
+                },
+            ],
+        }
+    ],
+}]

--- a/couchpotato/core/notifications/email/main.py
+++ b/couchpotato/core/notifications/email/main.py
@@ -1,0 +1,53 @@
+from couchpotato.core.helpers.encoding import toUnicode
+from couchpotato.core.logger import CPLog
+from couchpotato.core.notifications.base import Notification
+from email.mime.text import MIMEText
+import traceback
+import smtplib
+
+log = CPLog(__name__)
+
+
+class Email(Notification):
+
+    def notify(self, message = '', data = {}, listener = None):
+        if self.isDisabled(): return
+
+        # Extract all the settings from the database
+        from_address = self.conf('from')
+        to = self.conf('to')
+        smtp_server = self.conf('smtp_server')
+        ssl = self.conf('ssl')
+        smtp_user = self.conf('smtp_user')
+        smtp_pass = self.conf('smtp_pass')
+        
+        # Make the basic message
+        message = MIMEText(toUnicode(message))
+        message['Subject'] = self.conf('subject')
+        message['From'] = from_address
+        message['To'] = to
+        
+        try:
+            # Open the SMTP connection, via SSL if requested
+            if ssl == 1:
+                mailserver = smtplib.SMTP_SSL(smtp_server)
+            else:
+                mailserver = smtplib.SMTP(smtp_server)
+
+            
+            # Check too see if an login attempt should be attempted
+            if len(smtp_user) > 0:
+                mailserver.login(smtp_user, smtp_pass)
+            
+            # Send the e-mail
+            mailserver.sendmail(from_address, to, message.as_string())
+            
+            # Close the SMTP connection
+            mailserver.quit()
+            log.info('Email notifications sent.')
+            return True
+        except:
+            log.error('E-mail failed: %s', traceback.format_exc())
+            return False
+        
+        return False


### PR DESCRIPTION
Hello,

In issue 618 there was a request to add an e-mail notifier (https://github.com/RuudBurger/CouchPotatoServer/issues/618). The last comment was "If you want this, you can always send me a pull request ;)". This is that pull request :). I also missed the option to let Couch Potato notify me via an e-mail. Thus I created that notifier :).

I've only tested this on the platform I run Couch Potato on, which is Gentoo Linux with Python 2.7, but it works flawlessly there.

If you have any questions, please let me know.

Regards,
Cybertinus
