### PR TITLE
Fix a problem where a folder couldn't be deleted because it wasn't empty

### DIFF
--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -508,7 +508,7 @@ class Renamer(Plugin):
                 full_path = os.path.join(root, dir_name)
                 if len(os.listdir(full_path)) == 0:
                     try:
-                        os.rmdir(full_path)
+                        shutil.rmtree(full_path)
                     except:
                         loge('Couldn\'t remove empty directory %s: %s', (full_path, traceback.format_exc()))
 


### PR DESCRIPTION
I was frequently running into the following problem after a movie has been renamed:

```
[tato.core.plugins.renamer] Couldn't remove empty directory [...]
```

The original folder contained files and sub-folders. Since `os.rmdir()` can't delete non-empty directories, `shutil.rmtree()` should be used instead.
