### PR TITLE
Update init/fedora

### DIFF
--- a/init/fedora
+++ b/init/fedora
@@ -14,6 +14,11 @@
 prog=couchpotato
 lockfile=/var/lock/subsys/$prog
 
+# Source couchpotato configuration
+if [ -f /etc/sysconfig/couchpotato ]; then
+        . /etc/sysconfig/couchpotato
+fi
+
 ## Edit user configuation in /etc/sysconfig/couchpotato to change
 ## the defaults
 username=${CP_USER-couchpotato}
@@ -21,11 +26,6 @@ homedir=${CP_HOME-/opt/couchpotato}
 datadir=${CP_DATA-~/.couchpotato}
 pidfile=${CP_PIDFILE-/var/run/couchpotato/couchpotato.pid}
 ##
-
-# Source couchpotato configuration
-if [ -f /etc/sysconfig/couchpotato ]; then
-        . /etc/sysconfig/couchpotato
-fi
 
 pidpath=`dirname ${pidfile}`
 options=" --daemon --pid_file=${pidfile} --data_dir=${datadir}"


### PR DESCRIPTION
This reverts commit 3aabcbf8f159143fd89a7c1c56c05f6efd8443fa (pull request 1074) which broke the sysconfig/couchpotato integration. In the current form the variables from sysconfig will never be applied.

A sysconfig/couchpotato file should look like this:

```
CP_USER=couchpotato
CP_HOME=/foo/bar
```
