### PR TITLE
fixed utorrent status update of torrents (pause and label)

### DIFF
--- a/couchpotato/core/downloaders/utorrent/main.py
+++ b/couchpotato/core/downloaders/utorrent/main.py
@@ -4,6 +4,7 @@ from couchpotato.core.helpers.encoding import isInt, ss
 from couchpotato.core.logger import CPLog
 from hashlib import sha1
 from multipartpost import MultipartPostHandler
+from base64 import b32decode, b16encode
 import cookielib
 import httplib
 import re
@@ -40,7 +41,10 @@ class uTorrent(Downloader):
         if data.get('type') == 'torrent_magnet':
             torrent_hash = re.findall('urn:btih:([\w]{32,40})', data.get('url'))[0].upper()
             torrent_params['trackers'] = '%0D%0A%0D%0A'.join(self.torrent_trackers)
-        else:
+            # Convert base 32 to hex
+            if len(torrent_hash) == 32:
+                torrent_hash = b16encode(b32decode(torrent_hash))
+            else:
             info = bdecode(filedata)["info"]
             torrent_hash = sha1(bencode(info)).hexdigest().upper()
             torrent_filename = self.createFileName(data, filedata, movie)


### PR DESCRIPTION
Updated the torrent hash to check for a length of 32, and then reencodes it. Was needed to set the utorrent status correctly. Got the code from core\downloaders\base.py ;)
