### PR TITLE
Fixed the ubuntu initscript

### DIFF
--- a/init/ubuntu
+++ b/init/ubuntu
@@ -24,7 +24,6 @@ DAEMON=/usr/bin/python
 
 # Path to store PID file
 PID_FILE=/var/run/couchpotato.pid
-PID_PATH=$(dirname $PID_FILE)
 
 # script name
 NAME=couchpotato
@@ -44,9 +43,7 @@ set -e
 case "$1" in
   start)
         echo "Starting $DESC"
-        rm -rf $PID_PATH || return 1
-        install -d --mode=0755 -o $RUN_AS $PID_PATH || return 1
-        start-stop-daemon -d $APP_PATH -c $RUN_AS --start --background --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
+        start-stop-daemon -d $APP_PATH -c $RUN_AS --start --background --make-pidfile --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
         ;;
   stop)
         echo "Stopping $DESC"


### PR DESCRIPTION
So i tried to fix the initscript to not use dirty workarounds, as stated in https://github.com/RuudBurger/CouchPotatoServer/issues/1489#issuecomment-14766554

It _should_ work by now, i was a bit confused why you specified the pidfile in the arguments of CouchPotato.py as well, but i don't know how you make a daemon in python, so you will have had a reason for this. ;)
