### PR TITLE
Expose host setting from conf file in web interface

### DIFF
--- a/couchpotato/core/_base/_core/__init__.py
+++ b/couchpotato/core/_base/_core/__init__.py
@@ -29,7 +29,7 @@ config = [{
                     'type': 'int',
                     'description': 'The port I should listen to.',
                 },
-				{
+                {
                     'name': 'host',
                     'description': 'Hostname/IP clients should use to reference the server',
                     'advanced': True,


### PR DESCRIPTION
Host setting is hard to find/annoying to modify since there is no info about it anywhere in the settings.  I needed to set it so that the URL for the Growl notification icon was being generated properly for remote Growl clients.

Marginally related to issue #1363
