### PR TITLE
Add Advanced Option to deactivate "Too early to search for ..."

### DIFF
--- a/couchpotato/core/_base/_core/__init__.py
+++ b/couchpotato/core/_base/_core/__init__.py
@@ -94,6 +94,13 @@ config = [{
                     'label': 'File CHMOD',
                     'description': 'Same as Folder CHMOD but for files',
                 },
+                {
+                    'name': 'could_be_released',
+                    'default': 1,
+                    'type': 'bool',
+                    'label': 'Check Released',
+                    'description': 'Don\'t search if not released yet.',
+                },
             ],
         },
     ],

--- a/couchpotato/core/plugins/searcher/main.py
+++ b/couchpotato/core/plugins/searcher/main.py
@@ -157,7 +157,7 @@ class Searcher(Plugin):
 
         ret = False
         for quality_type in movie['profile']['types']:
-            if not self.couldBeReleased(quality_type['quality']['identifier'] in pre_releases, release_dates):
+            if Env.setting('could_be_released') and not self.couldBeReleased(quality_type['quality']['identifier'] in pre_releases, release_dates):
                 log.info('Too early to search for %s, %s', (quality_type['quality']['identifier'], default_title))
                 continue
 


### PR DESCRIPTION
https://github.com/RuudBurger/CouchPotatoServer/issues/1272

This is a problem with many not so big movies. I added a Advanced Option to deactivate this check. 

Since it's in the category Advanced "For those who know what they're doing" I don't see a problem to add this option. It's easier for people as to edit the python every time a update is loaded.

I set to default to the current, so the user has to deactivate the check once if he wants to.
