### PR TITLE
Fix the names of quality identifiers

### DIFF
--- a/couchpotato/core/plugins/quality/main.py
+++ b/couchpotato/core/plugins/quality/main.py
@@ -19,8 +19,8 @@ class QualityPlugin(Plugin):
 
     qualities = [
         {'identifier': 'bd50', 'hd': True, 'size': (15000, 60000), 'label': 'BR-Disk', 'alternative': ['bd25'], 'allow': ['1080p'], 'ext':[], 'tags': ['bdmv', 'certificate', ('complete', 'bluray')]},
-        {'identifier': '1080p', 'hd': True, 'size': (5000, 20000), 'label': '1080P', 'width': 1920, 'height': 1080, 'alternative': [], 'allow': [], 'ext':['mkv', 'm2ts'], 'tags': ['m2ts']},
-        {'identifier': '720p', 'hd': True, 'size': (3500, 10000), 'label': '720P', 'width': 1280, 'height': 720, 'alternative': [], 'allow': [], 'ext':['mkv', 'ts']},
+        {'identifier': '1080p', 'hd': True, 'size': (5000, 20000), 'label': '1080p', 'width': 1920, 'height': 1080, 'alternative': [], 'allow': [], 'ext':['mkv', 'm2ts'], 'tags': ['m2ts']},
+        {'identifier': '720p', 'hd': True, 'size': (3500, 10000), 'label': '720p', 'width': 1280, 'height': 720, 'alternative': [], 'allow': [], 'ext':['mkv', 'ts']},
         {'identifier': 'brrip', 'hd': True, 'size': (700, 7000), 'label': 'BR-Rip', 'alternative': ['bdrip'], 'allow': ['720p', '1080p'], 'ext':['avi']},
         {'identifier': 'dvdr', 'size': (3000, 10000), 'label': 'DVD-R', 'alternative': [], 'allow': [], 'ext':['iso', 'img'], 'tags': ['pal', 'ntsc', 'video_ts', 'audio_ts']},
         {'identifier': 'dvdrip', 'size': (600, 2400), 'label': 'DVD-Rip', 'width': 720, 'alternative': ['dvdrip'], 'allow': [], 'ext':['avi', 'mpg', 'mpeg'], 'tags': [('dvd', 'rip'), ('dvd', 'xvid'), ('dvd', 'divx')]},

--- a/couchpotato/core/plugins/renamer/__init__.py
+++ b/couchpotato/core/plugins/renamer/__init__.py
@@ -13,7 +13,7 @@ rename_options = {
         'thename': 'The Moviename',
         'year': 'Year (2011)',
         'first': 'First letter (M)',
-        'quality': 'Quality (720P)',
+        'quality': 'Quality (720p)',
         'video': 'Video (x264)',
         'audio': 'Audio (DTS)',
         'group': 'Releasegroup name',

--- a/couchpotato/core/plugins/trailer/__init__.py
+++ b/couchpotato/core/plugins/trailer/__init__.py
@@ -22,7 +22,7 @@ config = [{
                     'name': 'quality',
                     'default': '720p',
                     'type': 'dropdown',
-                    'values': [('1080P', '1080p'), ('720P', '720p'), ('480P', '480p')],
+                    'values': [('1080p', '1080p'), ('720p', '720p'), ('480P', '480p')],
                 },
                 {
                     'name': 'name',

--- a/couchpotato/core/settings/model.py
+++ b/couchpotato/core/settings/model.py
@@ -141,7 +141,7 @@ class Status(Entity):
 
 
 class Quality(Entity):
-    """Quality name of a release, DVD, 720P, DVD-Rip etc"""
+    """Quality name of a release, DVD, 720p, DVD-Rip etc"""
     using_options(order_by = 'order')
 
     identifier = Field(String(20), unique = True)


### PR DESCRIPTION
720P should be 720p, 1080P should be 1080p. Ref
http://en.wikipedia.org/wiki/720p and http://en.wikipedia.org/wiki/1080p

Note that this update only changes things for new databases. For as
far as I can see the change for existing databases is minimal (only the trainer quality naming and example text). If users really want the P to become a p they need to rebuild their database or change it manually. I think adding migration code for this is a bit extreme... ;)

Fixes #658
