### PR TITLE
added Python reserved word "return" where it was missing

### DIFF
--- a/couchpotato/core/notifications/base.py
+++ b/couchpotato/core/notifications/base.py
@@ -44,7 +44,7 @@ class Notification(Provider):
 
     def _notify(self, *args, **kwargs):
         if self.isEnabled():
-            self.notify(*args, **kwargs)
+            return self.notify(*args, **kwargs)
 
     def notify(self, message = '', data = {}, listener = None):
         pass


### PR DESCRIPTION
The UI always reports sending of test notifications as failures, even though they work perfectly fine. The problem is that the _notify method in base.py didn't return what the actual method/implementation returned.
