### PR TITLE
Disable NZBGet download_ID

### DIFF
--- a/couchpotato/core/downloaders/nzbget/main.py
+++ b/couchpotato/core/downloaders/nzbget/main.py
@@ -52,9 +52,9 @@ class NZBGet(Downloader):
 
         if xml_response:
             log.info('NZB sent successfully to NZBGet')
-            groups = rpc.listgroups()
-            nzb_id = [item['NZBID'] for item in groups if item['NZBFilename'] == nzb_name][0]
-            return self.downloadReturnId(nzb_id)
+            #groups = rpc.listgroups()
+            #nzb_id = [item['NZBID'] for item in groups if item['NZBFilename'] == nzb_name][0]
+            return True #self.downloadReturnId(nzb_id)
         else:
             log.error('NZBGet could not add %s to the queue.', nzb_name)
             return False


### PR DESCRIPTION
The NZBID as reported by NZBGet is reset for each session. This could
lead to CPS to link the download to the wrong release when NZBGet is
restarted. We asked the developer of NZBGet to help us here, but until
then, the NZBID is unreliable for NZB tracking.

ref. https://sourceforge.net/apps/phpbb/nzbget/viewtopic.php?f=3&t=629
