### PR TITLE
File Action : Move and Sym Link

### DIFF
--- a/couchpotato/core/plugins/renamer/__init__.py
+++ b/couchpotato/core/plugins/renamer/__init__.py
@@ -117,7 +117,7 @@ config = [{
                     'label': 'File Action',
                     'default': 'move',
                     'type': 'dropdown',
-                    'values': [('Move', 'move'), ('Copy', 'copy'), ('Hard link', 'hardlink'), ('Sym link', 'symlink')],
+                    'values': [('Move', 'move'), ('Copy', 'copy'), ('Hard link', 'hardlink'), ('Sym link', 'symlink'), ('Move & Sym link', 'move_symlink')],
                     'description': 'Define which kind of file operation you want to use. Before you start using <a href="http://en.wikipedia.org/wiki/Hard_link">hard links</a> or <a href="http://en.wikipedia.org/wiki/Sym_link">sym links</a>, PLEASE read about their possible drawbacks.',
                     'advanced': True,
                 },

--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -526,6 +526,9 @@ Remove it if you want it to be renamed (again, or at least let it try again)
                 linktastic.symlink(old, dest)
             elif self.conf('file_action') == 'copy':
                 shutil.copy(old, dest)
+            elif self.conf('file_action') == 'move_symlink':
+                shutil.move(old, dest)
+                linktastic.symlink(dest, old)
             else:
                 shutil.move(old, dest)
 


### PR DESCRIPTION
Hi there,

I tried to post this as a feature request on the forum, but unfortunately it kept complaining about some thread prefix and wouldn't let me post, so I'm just sending this here.

The problem is that some NAS do not support hard linking, in particular unRaid. As a result, the only option to rename and continue seeding are symbolic links. However, I think most people would prefer to have the symbolic link in the original directory, and the file itself get moved to their Movies directory. Meaning Seeding -> Movies, instead of the current Movies -> Seeding.

I added a few lines to create a new File Action, to move the file, and then create a symbolic link in its original location. This seems safer, as it allows people to remove the links when done seeding without breaking their moving collection.

Perhaps there is a better name for this option, or a work around I didn't think of.
