### PR TITLE
Fix text overlap when a movie title is 2 lines

### DIFF
--- a/couchpotato/core/plugins/movie/static/movie.css
+++ b/couchpotato/core/plugins/movie/static/movie.css
@@ -201,7 +201,8 @@
 
 			.movies .info .title {
 				display: inline;
-				position: absolute;
+				position: relative;
+				float: left;
 				font-size: 28px;
 				font-weight: bold;
 				margin-bottom: 10px;
@@ -264,8 +265,7 @@
 				}
 
 			.movies .info .description {
-				position: absolute;
-				top: 30px;
+				position: relative;
 				clear: both;
 				height: 80px;
 				overflow: hidden;


### PR DESCRIPTION
Ran into a bug where the text of a long movie title would overlap the description text due to hardcoded css.  I've changed a few lines in the css to fix this issue.
Before:
![Screen Shot 2013-04-17 at 4 05 54 PM](https://f.cloud.github.com/assets/423044/412769/fb92f72c-abcc-11e2-8863-a9a85e453645.png)
After:
![Screen Shot 2013-04-17 at 4 05 24 PM](https://f.cloud.github.com/assets/423044/412770/fe7acabe-abcc-11e2-8fc9-2eb1c70fcbdd.png)
