### PR TITLE
Add username to nzbget downloader

### DIFF
--- a/couchpotato/core/downloaders/nzbget/__init__.py
+++ b/couchpotato/core/downloaders/nzbget/__init__.py
@@ -25,6 +25,10 @@ config = [{
                     'description': 'Hostname with port. Usually <strong>localhost:6789</strong>',
                 },
                 {
+                    'name': 'username',
+                    'default': 'nzbget',
+                },
+                {
                     'name': 'password',
                     'type': 'password',
                     'description': 'Default NZBGet password is <i>tegbzn6789</i>',

--- a/couchpotato/core/downloaders/nzbget/main.py
+++ b/couchpotato/core/downloaders/nzbget/main.py
@@ -16,7 +16,7 @@ class NZBGet(Downloader):
 
     type = ['nzb']
 
-    url = 'http://nzbget:%(password)s@%(host)s/xmlrpc'
+    url = 'http://%(username):%(password)s@%(host)s/xmlrpc'
 
     def download(self, data = {}, movie = {}, filedata = None):
 
@@ -26,7 +26,7 @@ class NZBGet(Downloader):
 
         log.info('Sending "%s" to NZBGet.', data.get('name'))
 
-        url = self.url % {'host': self.conf('host'), 'password': self.conf('password')}
+        url = self.url % {'host': self.conf('host'), 'username': self.conf('username'), 'password': self.conf('password')}
         nzb_name = ss('%s.nzb' % self.createNzbName(data, movie))
 
         rpc = xmlrpclib.ServerProxy(url)
@@ -61,7 +61,7 @@ class NZBGet(Downloader):
 
         log.debug('Checking NZBGet download status.')
 
-        url = self.url % {'host': self.conf('host'), 'password': self.conf('password')}
+        url = self.url % {'host': self.conf('host'), 'username': self.conf('username'), 'password': self.conf('password')}
 
         rpc = xmlrpclib.ServerProxy(url)
         try:


### PR DESCRIPTION
For raspberry pi a different username than normal is required. Fixes
#1652
