### PR TITLE
Include IMDb link to movie in Pushover notifications

### DIFF
--- a/couchpotato/core/notifications/pushover/main.py
+++ b/couchpotato/core/notifications/pushover/main.py
@@ -18,7 +18,9 @@ class Pushover(Notification):
             'user': self.conf('user_key'),
             'token': self.app_token,
             'message': toUnicode(message),
-            'priority': self.conf('priority')
+            'priority': self.conf('priority'),
+            'url': toUnicode("http://www.imdb.com/title/%s" % data['library']['identifier']) if data else "",
+            'url_title': toUnicode("%s on IMDb" %  data['library']['titles'][0]['title']) if data else ""
         }
 
         http_handler.request('POST',


### PR DESCRIPTION
Pushover notifications have the option to include a url that is displayed when you highlight a notification inside the app.
I often don't know just from the title what movie has been downloaded. 
This change allows you to go to the movie's IMDb page directly from the notification to get more information about it.
