### PR TITLE
Adjust force renamer scan

### DIFF
--- a/couchpotato/core/plugins/renamer/__init__.py
+++ b/couchpotato/core/plugins/renamer/__init__.py
@@ -81,16 +81,16 @@ config = [{
                     'default': 1,
                     'type': 'int',
                     'unit': 'min(s)',
-                    'description': 'Detect movie status every X minutes. Will start the renamer if movie is <strong>completed</strong> or handle <strong>failed</strong> download if these options are enabled',
+                    'description': 'Detect movie status every X minutes (0 to disable). Will start the renamer if movie is <strong>completed</strong> or handle <strong>failed</strong> download if these options are enabled',
                 },
                 {
                     'advanced': True,
                     'name': 'force_every',
                     'label': 'Force every',
-                    'default': 2,
+                    'default': 0,
                     'type': 'int',
                     'unit': 'hour(s)',
-                    'description': 'Forces the renamer to scan every X hours',
+                    'description': 'Forces the renamer to process files in the \'From\' folder every X hours (0 to disable). This includes files added manually, <strong>but</strong> also <strong>incomplete</strong> or <strong>seeding</strong> torrents (!).',
                 },
                 {
                     'advanced': True,
@@ -102,7 +102,7 @@ config = [{
                 {
                     'name': 'move_leftover',
                     'type': 'bool',
-                    'description': 'Move all leftover file after renaming, to the movie folder.',
+                    'description': 'Move all leftover files after renaming, to the movie folder.',
                     'default': False,
                     'advanced': True,
                 },

--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -38,7 +38,8 @@ class Renamer(Plugin):
         addEvent('renamer.scan', self.scan)
         addEvent('renamer.check_snatched', self.checkSnatched)
 
-        addEvent('app.load', self.scan)
+        if self.conf('force_every') > 0:
+            addEvent('app.load', self.scan)
         addEvent('app.load', self.checkSnatched)
         addEvent('app.load', self.setCrons)
 


### PR DESCRIPTION
The force scan function causes trouble for several users. For example it
also picks up seeding torrents and may also pick up incomplete torrents
if there has been no downloading activity for > 1 minute.

This commit changes the following items:
- Disable it by default
- Only scan at start-up if the force scan is enabled (>0)
- Add a warning in settings that it can mess up torrents

We could remove the force scan function all together by simply adding a
manual button to scan the From folder. Note that if we do this, warnings
should be added that it also picks up seeding and potentially incomplete
torrents.

As a last note: there is no way to see from the file if it has completed
downloading or seeding! The only way is to ask the downloader. This
could mean that seeding or incomplete files should not be in the from
folder in the first place?
