### PR TITLE
Fix for Torrentleech login issue.

### DIFF
--- a/couchpotato/core/providers/base.py
+++ b/couchpotato/core/providers/base.py
@@ -104,7 +104,7 @@ class YarrProvider(Provider):
         try:
             cookiejar = cookielib.CookieJar()
             opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookiejar))
-            opener.addheaders = []
+            opener.addheaders = [('User-agent', 'Mozilla/5.0')]
             urllib2.install_opener(opener)
             log.info2('Logging into %s', self.urls['login'])
             f = opener.open(self.urls['login'], self.getLoginParams())


### PR DESCRIPTION
Set user-agent to Mozilla/5.0. Some providers (like Torrentleech) block the default user-agent of urllib2 (https://github.com/RuudBurger/CouchPotatoServer/issues/1719)

Maybe you want to make the fix more specific for Torrentleech. But for now I just added the user agent for all providers.
