### PR TITLE
Update base.py

### DIFF
--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -105,7 +105,7 @@ class Plugin(object):
         if not params: params = {}
 
         # Fill in some headers
-        headers['Referer'] = headers.get('Referer', urlparse(url).hostname)
+        #headers['Referer'] = headers.get('Referer', urlparse(url).hostname)
         headers['Host'] = headers.get('Host', urlparse(url).hostname)
         headers['User-Agent'] = headers.get('User-Agent', self.user_agent)
         headers['Accept-encoding'] = headers.get('Accept-encoding', 'gzip')


### PR DESCRIPTION
# Passing a hostname in the referer field causes problems with my indexer (nzb.ag), which uses CloudFlare and SSL. As the RFC states the Referer field is an optional field, I've chosen to comment out the line.

If this field was added for compatibility with other websites, an alternative could be to pass the full URL instead of just a hostname, but this doesn't make much sense as referer as it should really be the page that presented you with the link, not the URL we're trying to access.

headers['Referer'] = headers.get('Referer', url)

Without the update, the following log entry is shown in my logs.

06-01 14:38:36 ERROR [hpotato.core.plugins.base] Failed opening url in Newznab: https://nzb.ag/api?t=movie&imdbid=2034139&apikey=xxx&extended=1 Traceback (most recent call last):
  File "/volume1/@appstore/couchpotatoserver/share/CouchPotatoServer/couchpotato/core/plugins/base.py", line 149, in urlopen
    response = urllib2.urlopen(request, timeout = timeout)
HTTPError: HTTP Error 403: Forbidden

After the update, the above error is no longer showing.
