### PR TITLE
Error fix for Passthepopcorn searcher

### DIFF
--- a/couchpotato/core/providers/torrent/passthepopcorn/main.py
+++ b/couchpotato/core/providers/torrent/passthepopcorn/main.py
@@ -186,7 +186,7 @@ class PassThePopcorn(TorrentProvider):
             seen_one = False
 
             if not field in torrent:
-                log.debug('Torrent with ID %s has no field "%s"; cannot apply post-search-filter for quality "%s"', (torrent['Id'], field, quality))
+                log.debug('Torrent with ID %s has no field "%s"; cannot apply post-search-filter for quality "%s"', (torrent['id'], field, quality))
                 continue
 
             for spec in specs:


### PR DESCRIPTION
When PTP's response JSON had torrents without a field in the requirements it was supposed to be logged. However, the logging function references a key that will never exist "Id", changing to "id" allows the issue to be logged properly and the search to continue. You can see the key creation for id within the dict at line 126 of the same file.

You can reproduce this bug in the original code by searching for a 'SD' quality movie on any movie that has many different quality versions on PTP (needs at least one in the json that is missing 'Codec' information). You will get this error in the log:

```
[   couchpotato.core.event] Error in event "searcher.correct_movie", that wasn't caught: Traceback (most recent call last):
  File "/Users//cloned_tools/CouchPotatoServer/couchpotato/core/event.py", line 12, in runHandler
    return handler(*args, **kwargs)
  File "/Users//cloned_tools/CouchPotatoServer/couchpotato/core/plugins/searcher/main.py", line 441, in correctMovie
    if extra_check and not extra_check(nzb):
  File "/Users//cloned_tools/CouchPotatoServer/couchpotato/core/providers/torrent/passthepopcorn/main.py", line 123, in extra_check
    return self.torrentMeetsQualitySpec(item, quality_id)
  File "/Users//cloned_tools/CouchPotatoServer/couchpotato/core/providers/torrent/passthepopcorn/main.py", line 189, in torrentMeetsQualitySpec
    log.debug('Torrent with ID %s has no field "%s"; cannot apply post-search-filter for quality "%s"', (torrent['Id'], field, quality))
KeyError: 'Id'
encoding=UTF-8 debug=False args=[] app_dir=/Users//cloned_tools/CouchPotatoServer data_dir=/Users//Library/Application Support/CouchPotato desktop=None options=Namespace(config_file='/Users//Library/Application Support/CouchPotato/settings.conf', console_log=False, daemon=False, data_dir=None, debug=False, pid_file='/Users//Library/Application Support/CouchPotato/couchpotato.pid', quiet=False) 
```
