### PR TITLE
Spotweb preferred spotters

### DIFF
--- a/couchpotato/core/plugins/score/main.py
+++ b/couchpotato/core/plugins/score/main.py
@@ -47,7 +47,9 @@ class Score(Plugin):
         score += halfMultipartScore(nzb['name'])
 
         # Check if there is a preferred spotter
-        score += spotterScore(nzb['spotter'])
+        # If spotter value is empty, then it is not on spotweb
+        if nzb.has_key('spotter'):
+            score += spotterScore(nzb['spotter'])
 
         # Extra provider specific check
         extra_score = nzb.get('extra_score')

--- a/couchpotato/core/plugins/score/scores.py
+++ b/couchpotato/core/plugins/score/scores.py
@@ -64,7 +64,7 @@ def spotterScore(spotter):
 
     for sp in preferred_spotter:
         if sp.strip() and sp.strip().lower() in spotter:
-            score = score + 500
+            score = score + 800
 
     return score
 

--- a/couchpotato/core/plugins/searcher/__init__.py
+++ b/couchpotato/core/plugins/searcher/__init__.py
@@ -24,7 +24,7 @@ config = [{
                     'name': 'preferred_spotter',
                     'label': 'Preferred Spotter',
                     'default': '',
-                    'description': 'These spotter names get a higher score.'
+                    'description': 'These Spotweb spotter names get a higher score.'
                 },
                 {
                     'name': 'required_words',

--- a/couchpotato/core/providers/nzb/newznab/main.py
+++ b/couchpotato/core/providers/nzb/newznab/main.py
@@ -10,6 +10,7 @@ from urllib2 import HTTPError
 from urlparse import urlparse
 import time
 import traceback
+from pprint import pprint
 
 log = CPLog(__name__)
 
@@ -49,11 +50,12 @@ class Newznab(NZBProvider, RSS):
         url = '%s&%s' % (self.getUrl(host['host'], self.urls['search']), arguments)
 
         nzbs = self.getRSSData(url, cache_timeout = 1800, headers = {'User-Agent': Env.getIdentifier()})
-        
-        for nzb in nzbs:
+              
 
+        for nzb in nzbs:   
+                       
             date = None
-            poster = None
+            spotter = None
             for item in nzb:
                 if date and poster:
                     break
@@ -62,13 +64,12 @@ class Newznab(NZBProvider, RSS):
                     break
                 # Get the name of the person who posts the spot
                 if item.attrib.get('name') == 'poster':
-                    # Split the value so we only get the name
-                    spotter = item.attrib.get('value').split("@")[0]
-                    
-                    # Debug
-                    #f.write("\n" + spotter)
-                    
-                    continue
+                    # We only want spotnet posters, so it does not break
+                    # other newznab providers
+                    if "@spot.net" in item.attrib.get('value'):
+                        # Split the value so we only get the name
+                        spotter = item.attrib.get('value').split("@")[0]
+                        continue
 
             if not date:
                 date = self.getTextElement(nzb, 'pubDate')


### PR DESCRIPTION
I made some changes after the last pull got rejected.
I now check if the spotter has a spotweb id, otherwise it does nothing, so it does not brake other newznab providers.
