### PR TITLE
Adjustment search strategy NZBIndex

### DIFF
--- a/couchpotato/core/providers/nzb/nzbindex/main.py
+++ b/couchpotato/core/providers/nzb/nzbindex/main.py
@@ -23,7 +23,7 @@ class NzbIndex(NZBProvider, RSS):
 
     def _searchOnTitle(self, title, movie, quality, results):
 
-        q = '"%s %s"' % (title, movie['library']['year'])
+        q = '"%s %s" | "%s (%s)"' % (title, movie['library']['year'], title, movie['library']['year'])
         arguments = tryUrlencode({
             'q': q,
             'age': Env.setting('retention', 'nzb'),


### PR DESCRIPTION
In the case of NzbIndex (probably applicable to other providers as well) searching for "title year" will not show results with () surrounding the year. This will increase the chance of finding the movie
