### PR TITLE
Ability to use MySQL or other DB Engines

### DIFF
--- a/CouchPotato.py
+++ b/CouchPotato.py
@@ -54,6 +54,11 @@ class Loader(object):
         # Logging
         from couchpotato.core.logger import CPLog
         self.log = CPLog(__name__)
+        
+        # DB URI Command line Option to overide database
+        self.db_uri = None
+        if self.options.db_uri:
+            self.db_uri = self.options.db_uri
 
         formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s', '%H:%M:%S')
         hdlr = handlers.RotatingFileHandler(os.path.join(self.log_dir, 'error.log'), 'a', 500000, 10)
@@ -80,7 +85,7 @@ class Loader(object):
         self.addSignals()
 
         from couchpotato.runner import runCouchPotato
-        runCouchPotato(self.options, base_path, sys.argv[1:], data_dir = self.data_dir, log_dir = self.log_dir, Env = Env)
+        runCouchPotato(self.options, base_path, sys.argv[1:], data_dir = self.data_dir, log_dir = self.log_dir, db_uri = self.db_uri, Env = Env)
 
         if self.do_restart:
             self.restart()

--- a/couchpotato/core/settings/model.py
+++ b/couchpotato/core/settings/model.py
@@ -74,8 +74,8 @@ class LibraryTitle(Entity):
     """"""
     using_options(order_by = '-default')
 
-    title = Field(Unicode)
-    simple_title = Field(Unicode, index = True)
+    title = Field(Unicode(250))
+    simple_title = Field(Unicode(250), index = True)
     default = Field(Boolean, default = False, index = True)
 
     language = OneToMany('Language')
@@ -86,7 +86,7 @@ class Language(Entity):
     """"""
 
     identifier = Field(String(20), index = True)
-    label = Field(Unicode)
+    label = Field(Unicode(200))
 
     titles = ManyToOne('LibraryTitle')
 

--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -35,6 +35,8 @@ def getOptions(base_path, args):
                         dest = 'daemon', help = 'Daemonize the app')
     parser.add_argument('--pid_file',
                         dest = 'pid_file', help = 'Path to pidfile needed for daemon')
+    parser.add_argument('--db_uri',
+                        dest = 'db_uri', help = 'URI to database (if not using sqlite). eg mysql://user:pass@localhost/cp')
 
     options = parser.parse_args(args)
 
@@ -64,7 +66,7 @@ def _log(status_code, request):
     log_method("%d %s %.2fms", status_code, summary, request_time)
 
 
-def runCouchPotato(options, base_path, args, data_dir = None, log_dir = None, Env = None, desktop = None):
+def runCouchPotato(options, base_path, args, data_dir = None, log_dir = None, db_uri = None, Env = None, desktop = None):
 
     try:
         locale.setlocale(locale.LC_ALL, "")
@@ -115,6 +117,8 @@ def runCouchPotato(options, base_path, args, data_dir = None, log_dir = None, En
     Env.set('data_dir', toUnicode(data_dir))
     Env.set('log_path', toUnicode(os.path.join(log_dir, 'CouchPotato.log')))
     Env.set('db_path', toUnicode('sqlite:///' + db_path))
+    if db_uri is not None:
+        Env.set('db_path', toUnicode(db_uri))
     Env.set('cache_dir', toUnicode(os.path.join(data_dir, 'cache')))
     Env.set('cache', FileSystemCache(toUnicode(os.path.join(Env.get('cache_dir'), 'python'))))
     Env.set('console_log', options.console_log)


### PR DESCRIPTION
Added command line handler, for -db_uri, to give users the ability to specifiy the uri that is passed to SQLAlchemy.

I am currently running on MySQL in a SmartOS Zone, and it is working well.

Had to fix some column definitions, I am unsure as to the effect that this has had on the SQLite driver, should be ok though (I believe it ignores lengths on varchar columns.
