### PR TITLE
Added priority setting for SABnzbd

### DIFF
--- a/couchpotato/core/downloaders/sabnzbd/__init__.py
+++ b/couchpotato/core/downloaders/sabnzbd/__init__.py
@@ -35,6 +35,15 @@ config = [{
                     'description': 'The category CP places the nzb in. Like <strong>movies</strong> or <strong>couchpotato</strong>',
                 },
                 {
+                    'name': 'priority',
+                    'label': 'Priority',
+                    'type': 'dropdown',
+                    'default': '0',
+                    'advanced': True,
+                    'values': [('Paused', -2), ('Low', -1), ('Normal', 0), ('High', 1), ('Forced', 2)],
+                    'description': 'Priority in the SABnzbd queue. Option to add paused.',
+                },
+                {
                     'name': 'manual',
                     'default': False,
                     'type': 'bool',

--- a/couchpotato/core/downloaders/sabnzbd/main.py
+++ b/couchpotato/core/downloaders/sabnzbd/main.py
@@ -22,6 +22,7 @@ class Sabnzbd(Downloader):
             'cat': self.conf('category'),
             'mode': 'addurl',
             'nzbname': self.createNzbName(data, movie),
+            'priority': self.conf('priority'),
         }
 
         if filedata:


### PR DESCRIPTION
Includes ability to add nzb to queue paused.

This is the same as #1897 which got royally messed up somehow. This is also in what I believe is the proper branch, unlike #1897 which was in master.
