### PR TITLE
Add Rating / Genre to Dashboard Suggestions

### DIFF
--- a/couchpotato/core/plugins/movie/static/search.js
+++ b/couchpotato/core/plugins/movie/static/search.js
@@ -223,6 +223,14 @@ Block.Search.Item = new Class({
 							'text': info.year
 						}) : null
 					)
+				).adopt(
+						self.rating = info.rating && info.rating.imdb.length > 0 && info.rating.imdb[0] != '0'  ? new Element('span.rating', {
+							'text': info.rating.imdb[0] + '/10'
+						}) : null
+				).adopt(
+						self.genre = info.genres && info.genres.length > 0 ? new Element('span.genres', {
+							'text': self.getGenres(info.genres)
+						}) : null
 				)
 			)
 		)
@@ -239,6 +247,17 @@ Block.Search.Item = new Class({
 		var self = this;
 
 		self.alternative_titles.include(alternative);
+	},
+
+	getGenres: function(data){
+		var self = this;
+		var genres = [];
+		
+		for (var i=0;i<data.length && i<3;i++) {
+			genres[i] = data[i];
+		}
+		
+		return genres.join(' | ');
 	},
 
 	getTitle: function(){

--- a/couchpotato/core/plugins/suggestion/static/suggest.css
+++ b/couchpotato/core/plugins/suggestion/static/suggest.css
@@ -42,12 +42,19 @@
 			line-height: 18px;
 		}
 			
+		.suggestions .movie_result .data .info .rating,
+		.suggestions .movie_result .data .info .genres,
 		.suggestions .movie_result .data .info .year {
 			position: static;
 			display: block;
 			margin: 5px 0 0;
 			padding: 0;
 			opacity: .6;
+		}
+		
+		.suggestions .movie_result .data .info .rating,
+		.suggestions .movie_result .data .info .genres {
+			font-size: 10px;
 		}
 		
 	.suggestions .movie_result .data {


### PR DESCRIPTION
Add Rating and up to 3 Genres to movie suggestions, to avoid constantly having to jump to IMDB site.

Found myself constantly going to the IMDB site to check that info. Seeing as it was already present in the variable, thought it would be a good addition to display it.

![develop_suggestionratinggenres](https://f.cloud.github.com/assets/4953841/787400/dc4d6b86-ead8-11e2-8aef-f73294291d68.png)
