### PR TITLE
Update movie.actions.js to allow playing trailers when using https

### DIFF
--- a/couchpotato/core/plugins/movie/static/movie.actions.js
+++ b/couchpotato/core/plugins/movie/static/movie.actions.js
@@ -408,7 +408,7 @@ MA.Trailer = new Class({
 	watch: function(offset){
 		var self = this;
 
-		var data_url = 'http://gdata.youtube.com/feeds/videos?vq="{title}" {year} trailer&max-results=1&alt=json-in-script&orderby=relevance&sortorder=descending&format=5&fmt=18'
+		var data_url = '//gdata.youtube.com/feeds/videos?vq="{title}" {year} trailer&max-results=1&alt=json-in-script&orderby=relevance&sortorder=descending&format=5&fmt=18'
 		var url = data_url.substitute({
 				'title': encodeURI(self.getTitle()),
 				'year': self.get('year'),


### PR DESCRIPTION
When the server is hosted using https, an error occurs when trying to play trailers:

[blocked] The page at https://example.com:5000/manage/ ran insecure content from http://gdata.youtube.com/feeds/videos?...

By removing the http: from the data_url var a protocol-relative link is used instead. This will throw an https warning, but the trailer will successfully play.
