### PR TITLE
set the default port to match the other default, 5050

### DIFF
--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -212,7 +212,7 @@ def runCouchPotato(options, base_path, args, data_dir = None, log_dir = None, En
     # app.debug = development
     config = {
         'use_reloader': reloader,
-        'port': tryInt(Env.setting('port', default = 5000)),
+        'port': tryInt(Env.setting('port', default = 5050)),
         'host': host if host and len(host) > 0 else '0.0.0.0',
         'ssl_cert': Env.setting('ssl_cert', default = None),
         'ssl_key': Env.setting('ssl_key', default = None),


### PR DESCRIPTION
I noticed CP starting at port 5000, then later, when a default settings.conf is created in the data dir, CP will restart at 5050,
since that is the default.

I think the reason CP starts at 5000 because this setting, hence
changing it would be best.
