### PR TITLE
Some times CP comes up with an empty body

### DIFF
--- a/couchpotato/templates/index.html
+++ b/couchpotato/templates/index.html
@@ -21,7 +21,7 @@
 		<script type="text/javascript" src="https://www.youtube.com/player_api" defer="defer"></script>
 
 		<script type="text/javascript">
-			$(function() {
+			window.addEvent('domready', function() {
 				if($(window).getSize().x <= 480)
 					window.addEvent('load', function() {
 
@@ -30,9 +30,7 @@
 							window.scrollTo(0, 0);
 						}, 100);
 					});
-			});
 
-			window.addEvent('domready', function() {
 				new Uniform();
 
 				Api.setup({


### PR DESCRIPTION
Hi, I find that CP comes up with an empty body often. The HTML is not empty, tho, so the app is alive. See gist:6280227 for what it generates.

There are no errors in the data dir at data/logs/CouchPotato.log

On a hunch, I took at look at the JS console and it looks like 

```
ReferenceError: $ is not defined
[Break On This Error]   

if($(window).getSize().x <= 480)
```

restarting the server eventually seems to generate a proper app, suggesting a race condition.

This patch appears to reliably work by making sure the code runs when
the DOM has finished loading.
