### PR TITLE
add support for Flixster "Want-to-see" list automation

### DIFF
--- a/couchpotato/core/providers/automation/flixster/__init__.py
+++ b/couchpotato/core/providers/automation/flixster/__init__.py
@@ -1,0 +1,34 @@
+from .main import Flixster
+
+def start():
+    return Flixster()
+
+config = [{
+    'name': 'flixster',
+    'groups': [
+        {
+            'tab': 'automation',
+            'list': 'watchlist_providers',
+            'name': 'flixster_automation',
+            'label': 'Flixster',
+            'description': 'Import movies from any public <a href="http://www.flixster.com/">Flixster</a> watchlist',
+            'options': [
+                {
+                    'name': 'automation_enabled',
+                    'default': False,
+                    'type': 'enabler',
+                },
+                {
+                    'name': 'automation_urls_use',
+                    'label': 'Use',
+                },
+                {
+                    'name': 'automation_urls',
+                    'label': 'User_ID',
+                    'type': 'combined',
+                    'combine': ['automation_urls_use', 'automation_urls'],
+                },
+            ],
+        },
+    ],
+}]

--- a/couchpotato/core/providers/automation/flixster/main.py
+++ b/couchpotato/core/providers/automation/flixster/main.py
@@ -1,0 +1,48 @@
+from couchpotato.core.helpers.variable import tryInt, splitString
+from couchpotato.core.logger import CPLog
+from couchpotato.core.providers.automation.base import Automation
+import json
+
+log = CPLog(__name__)
+
+
+class Flixster(Automation):
+
+    url = 'http://www.flixster.com/api/users/%s/movies/ratings?scoreTypes=wts'
+
+    interval = 60
+
+    def getIMDBids(self):
+
+        urls = splitString(self.conf('automation_urls'))
+
+        if len(urls) == 0:
+            return []
+
+        movies = []
+
+        for movie in self.getWatchlist():
+            imdb_id = self.search(movie.get('title'), movie.get('year'), imdb_only = True)
+            movies.append(imdb_id)
+
+        return movies
+
+    def getWatchlist(self):
+
+        enablers = [tryInt(x) for x in splitString(self.conf('automation_urls_use'))]
+        urls = splitString(self.conf('automation_urls'))
+
+        index = -1
+        movies = []
+        for username in urls:
+
+            index += 1
+            if not enablers[index]:
+                continue
+
+            data = json.loads(self.getHTMLData(self.url % username))
+
+            for movie in data:
+                movies.append({'title': movie['movie']['title'], 'year': movie['movie']['year'] })
+
+        return movies


### PR DESCRIPTION
Allows users to input one or more Flixtser user_ids to automatically add Flixster Want-To-See movies to CouchPotato's wanted list.

fixes #432

<!---
@huboard:{"order":1985.0}
-->
