### PR TITLE
Remove all empty folders after rename

### DIFF
--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -476,18 +476,18 @@ class Renamer(Plugin):
                     log.error('Failed removing %s: %s', (release.identifier, traceback.format_exc()))
 
             if group['dirname'] and group['parentdir'] and not self.downloadIsTorrent(download_info):
+                if movie_folder:
+                    # Delete the movie folder
+                    group_folder = movie_folder
+                else:
+                    # Delete the first empty subfolder in the tree relative to the 'from' folder
+                    group_folder = os.path.join(self.conf('from'), os.path.relpath(group['parentdir'], self.conf('from')).split(os.path.sep)[0])
+
                 try:
-                    if movie_folder:
-                        # Delete the movie folder
-                        group_folder = movie_folder
-                    else:
-                        # Delete the first empty subfolder in the tree relative to the 'from' folder
-                        group_folder = os.path.join(self.conf('from'), os.path.relpath(group['parentdir'], self.conf('from')).split(os.path.sep)[0])
-                            
                     log.info('Deleting folder: %s', group_folder)
                     self.deleteEmptyFolder(group_folder)
                 except:
-                    log.error('Failed removing %s: %s', (group['parentdir'], traceback.format_exc()))
+                    log.error('Failed removing %s: %s', (group_folder, traceback.format_exc()))
 
             # Notify on download, search for trailers etc
             download_message = 'Downloaded %s (%s)' % (movie_title, replacements['quality'])


### PR DESCRIPTION
Quite often there is a subfolder in the movie folder after extraction.
This folder is deleted but the base movie folder itself remains behind. This
update fixes that in both possible cases: move_folder is already known, or we work in the
'from' folder.

<!---
@huboard:{"order":1984.0}
-->
