### PR TITLE
Check explicitly for None

### DIFF
--- a/couchpotato/core/plugins/manage/main.py
+++ b/couchpotato/core/plugins/manage/main.py
@@ -170,7 +170,7 @@ class Manage(Plugin):
         self.in_progress = False
 
     def createAddToLibrary(self, folder, added_identifiers = None):
-        if not added_identifiers: added_identifiers = []
+        if added_identifiers is None: added_identifiers = []
 
         def addToLibrary(group, total_found, to_go):
             if self.in_progress[folder]['total'] is None:


### PR DESCRIPTION
The statement 'not added_identifiers' is evaluating to True.  This is causing the calling method to always have an empty list, because the 'added_identifiers = []' statement is only changing the local variable, rather than the calling method's variable.  During the cleanup stage, all movies are removed from the manage list because none of them show up in the added_identifiers list.

This may apply to the other places in RuudBurger/CouchPotatoServer@779c7d29423ce86082f25889324d22d6a82bc5ee where similar things were done, but I don't know what is mean by "Remove mutable objects from function args"
