### PR TITLE
Fixed Plex notifications on latest PHT

### DIFF
--- a/couchpotato/core/notifications/plex/main.py
+++ b/couchpotato/core/notifications/plex/main.py
@@ -52,7 +52,7 @@ class Plex(Notification):
                     clients.remove(server.get('name').lower())
                     protocol = server.get('protocol', 'xbmchttp')
 
-                    if protocol in ['xbmcjson', 'xbmchttp']:
+                    if protocol in ['plex', 'xbmcjson', 'xbmchttp']:
                         self.clients[server.get('name')] = {
                             'name': server.get('name'),
                             'address': server.get('address'),
@@ -164,7 +164,7 @@ class Plex(Notification):
         }
 
         for name, client in self.clients.items():
-            if client['protocol'] == 'xbmcjson':
+            if client['protocol'] in ['xbmcjson', 'plex']:
                 total += 1
                 if self.sendJSON('GUI.ShowNotification', params, client):
                     successful += 1


### PR DESCRIPTION
In a recent update to Plex Home Theater they decided to rename the JSON protocol in /clients from 'xbmcjson' to 'plex' which broke notifications, so this is the very small fix for it.

<!---
@huboard:{"order":1983.625}
-->
