### PR TITLE
Fix for completed uTorrent downloads having read permissions stripped on Linux

### DIFF
--- a/couchpotato/core/downloaders/utorrent/main.py
+++ b/couchpotato/core/downloaders/utorrent/main.py
@@ -206,7 +206,9 @@ class uTorrent(Downloader):
         if folder and os.path.isdir(folder):
             for root, folders, filenames in os.walk(folder):
                 for filename in filenames:
-                    os.chmod(os.path.join(root, filename), stat.S_IWRITE)
+                    filepath = os.path.join(root, filename)
+                    #Windows only needs S_IWRITE, but we bitwise-or with current perms to preserve other permission bits on Linux
+                    os.chmod(filepath, stat.S_IWRITE | os.stat(filepath).st_mode)
 
 class uTorrentAPI(object):
 


### PR DESCRIPTION
The fix for #1871 introduced a bug on Linux which strips read permissions from completed uTorrent downloads. If the downloaded file does not have its own directory then this also strips read permissions from all other files in the downloads directory, recursively. This PR includes a fix to add user write perms as intended while preserving existing permission bits on Linux. It should not change behavior on Windows (though I have not tested) since all other bits should be ignored in Windows os.chmod.
