### PR TITLE
TorrentShack provider: Fixed search criteria to work with multi-word titles.

### DIFF
--- a/couchpotato/core/providers/torrent/torrentshack/main.py
+++ b/couchpotato/core/providers/torrent/torrentshack/main.py
@@ -33,7 +33,7 @@ class TorrentShack(TorrentProvider):
 
         scene_only = '1' if self.conf('scene_only') else ''
 
-        url = self.urls['search'] % (tryUrlencode('%s %s' % (title.replace(':', ''), movie['library']['year'])), scene_only, self.getCatId(quality['identifier'])[0])
+        url = self.urls['search'] % (tryUrlencode('%s %s' % (title.replace(':', '').replace(' ', '_'), movie['library']['year'])), scene_only, self.getCatId(quality['identifier'])[0])
         data = self.getHTMLData(url, opener = self.login_opener)
 
         if data:


### PR DESCRIPTION
Search string as composed before was in form ["title" year]. But this did not work for longer titles - for example for After Earth search string was ["After Earth" 2013]. TorrentShack then required the releases to have space in name and most of relevant results were filtered out (they have dot in name). Changed search to replace space in the title with underscore which works as a wildchar. So the search string is now ["After_Earth" 2013].
