### PR TITLE
Prevent key error when ['files'] doesn't exist

### DIFF
--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -136,7 +136,7 @@ class Renamer(Plugin):
             movie_folder = movie_folder.rstrip(os.path.sep)
             folder = os.path.dirname(movie_folder)
 
-            if release_download.has_key('files'):
+            if release_download.get('files'):
                 files = release_download['files'].split('|')
 
                 # If there is only one file in the torrent, the downloader did not create a subfolder


### PR DESCRIPTION
This happens when triggered from Api.

<!---
@huboard:{"order":992.09375}
-->
