### PR TITLE
rTorrent: Delete Torrent Directories

### DIFF
--- a/couchpotato/core/downloaders/rtorrent/main.py
+++ b/couchpotato/core/downloaders/rtorrent/main.py
@@ -214,6 +214,14 @@ class rTorrent(Downloader):
             for file_item in torrent.get_files(): # will only delete files, not dir/sub-dir
                 os.unlink(os.path.join(torrent.directory, file_item.path))
 
+            if torrent.is_multi_file() and torrent.directory.endswith(torrent.name):
+                # Remove empty directories bottom up
+                try:
+                    for path, _, _ in os.walk(torrent.directory, topdown=False):
+                        os.rmdir(path)
+                except OSError:
+                    log.info('Directory "%s" contains extra files, unable to remove', torrent.directory)
+
         torrent.erase() # just removes the torrent, doesn't delete data
 
         return True


### PR DESCRIPTION
This should remove directories of torrents safely, this only removes the directories on torrents flagged as 'multi-file', checks the torrent directory ends with the directory name of the torrent to ensure we don't have the root somehow and only removes directories that are empty (as the files should be removed on #L215)

I'm not able to test this as I don't have a working setup with rTorrent, @jkaberg could you check this?
