### PR TITLE
Emails are rejected by amavis due to invalid headers

### DIFF
--- a/couchpotato/core/notifications/email/main.py
+++ b/couchpotato/core/notifications/email/main.py
@@ -4,6 +4,7 @@ from couchpotato.core.logger import CPLog
 from couchpotato.core.notifications.base import Notification
 from couchpotato.environment import Env
 from email.mime.text import MIMEText
+from email import Utils
 import smtplib
 import traceback
 
@@ -30,6 +31,8 @@ class Email(Notification):
         message['Subject'] = self.default_title
         message['From'] = from_address
         message['To'] = to_address
+        message['Date']     = Utils.formatdate(localtime = 1)
+        message['Message-ID'] = Utils.make_msgid()
 
         try:
             # Open the SMTP connection, via SSL if requested


### PR DESCRIPTION
amavis checks for rfc compliance in the email headers and will reject emails that do not provide the required entries.

This patch provides those required headers to prevent that rejection.
