### PR TITLE
Removed the use of the 'searcher.get_media_searcher_id' event

### DIFF
--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -167,7 +167,7 @@ def natcmp(a, b):
     return cmp(natsortKey(a), natsortKey(b))
 
 def toIterable(value):
-    if isinstance(value, collections.Iterable):
+    if type(value) in [list, tuple]:
         return value
     return [value]
 

--- a/couchpotato/core/providers/base.py
+++ b/couchpotato/core/providers/base.py
@@ -1,6 +1,6 @@
 from couchpotato.core.event import addEvent, fireEvent
 from couchpotato.core.helpers.variable import tryFloat, mergeDicts, md5, \
-    possibleTitles, getTitle
+    possibleTitles, getTitle, toIterable
 from couchpotato.core.logger import CPLog
 from couchpotato.core.plugins.base import Plugin
 from couchpotato.environment import Env
@@ -117,7 +117,9 @@ class YarrProvider(Provider):
     def __init__(self):
         addEvent('provider.enabled_protocols', self.getEnabledProtocol)
         addEvent('provider.belongs_to', self.belongsTo)
-        addEvent('provider.search.%s.%s' % (self.protocol, self.type), self.search)
+
+        for type in toIterable(self.type):
+            addEvent('provider.search.%s.%s' % (self.protocol, type), self.search)
 
     def getEnabledProtocol(self):
         if self.isEnabled():


### PR DESCRIPTION
This just pulls over the changes from the TV branch in PR #2523
