### PR TITLE
Adding in a new source for automation.

### DIFF
--- a/couchpotato/core/providers/automation/popular_movies/__init__.py
+++ b/couchpotato/core/providers/automation/popular_movies/__init__.py
@@ -1,0 +1,24 @@
+from .main import PopularMovies
+
+def start():
+    return PopularMovies()
+
+config = [{
+    'name': 'popular_movies',
+    'groups': [
+        {
+            'tab': 'automation',
+            'list': 'automation_providers',
+            'name': 'popular_movies_automation',
+            'label': 'Popular Movies',
+            'description': 'Imports the top titles of movies that have been in theaters.',
+            'options': [
+                {
+                    'name': 'automation_enabled',
+                    'default': False,
+                    'type': 'enabler',
+                },
+            ],
+        },
+    ],
+}]

--- a/couchpotato/core/providers/automation/popular_movies/main.py
+++ b/couchpotato/core/providers/automation/popular_movies/main.py
@@ -1,0 +1,22 @@
+from couchpotato.core.logger import CPLog
+from couchpotato.core.providers.automation.base import Automation
+import datetime
+
+log = CPLog(__name__)
+
+
+class PopularMovies(Automation):
+
+    interval = 1800
+    url = 'https://s3.amazonaws.com/popular-movies/movies.json'
+
+    def getIMDBids(self):
+
+        movies = []
+        retrieved_movies = self.getJsonData(self.url)
+
+        for movie in retrieved_movies.get('movies'):
+            imdb_id = movie.get('imdb_id')
+            movies.append(imdb_id)
+
+        return movies


### PR DESCRIPTION
I've created a tool which tries to automatically create a list of movies that were popular and in theaters (at least in the US). I found that a lot of the current sources add in a lot of junk that I wish not to have and weren't curated enough.

It'll look up TMDb and RT for movies that have active views (also known as their popularity). We then look up IMDB, TMDb, and RT for appropriate information to generate stats. It'll will weed out movies first that have certain low pin points such as ratings, budget, number of votes and popularity. With movies that pass that iteration, we generate a set of values which we will grade other movies upon. These include average rating, average number of reviews, average budget, popular actors, popular directors and popular studios. If they pass a certain number of auto-generated rules, they'll be added into the list.

Data can be seen visually:
http://movies.stevenlu.com/

This data is cached every 6 hours and placed into an S3 bucket.
https://s3.amazonaws.com/popular-movies/movies.json

There is also some aggregation that displays the relevant information:
http://movies.stevenlu.com/api/detail

I have tested this in my own copy of CP, automation properly adds into list and downloads the correct movie titles.
