### PR TITLE
Added the backslash as a path delimiter to the renamer

### DIFF
--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -126,7 +126,7 @@ class Renamer(Plugin):
             if len(splitString(release_download.get('files'), '|')) == 1:
                 new_movie_folder = from_folder
             else:
-                new_movie_folder = os.path.join(from_folder, os.path.basename(movie_folder))
+                new_movie_folder = os.path.join(from_folder, os.path.basename(movie_folder).split("\\")[-1])
 
             if not os.path.isdir(new_movie_folder):
                 log.error('The provided movie folder %s does not exist and could also not be found in the \'from\' folder.', movie_folder)


### PR DESCRIPTION
Added the backslash as a path delimiter to fix the issue where CP is unable to find a move folder in the 'from' folder when Sab runs on a Windows machine.
