### PR TITLE
Mark release as downloaded if renamer is disabled.

### DIFF
--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -333,7 +333,7 @@ class Release(Plugin):
             log.error('Failed storing download status: %s', traceback.format_exc())
             return False
 
-        return False
+        return True
 
     def tryDownloadResult(self, results, media, quality_type, manual = False):
         ignored_status, failed_status = fireEvent('status.get', ['ignored', 'failed'], single = True)


### PR DESCRIPTION
if the renamer is not enabled and the quality of the downloaded release
is not the finish quality, the release did not get a status update.

Fixes #2598
