### PR TITLE
BeautifulSoup not returning any data with html5lib and AttributeError when no results are found

### DIFF
--- a/couchpotato/core/providers/torrent/bitsoup/main.py
+++ b/couchpotato/core/providers/torrent/bitsoup/main.py
@@ -18,12 +18,20 @@ class Bitsoup(TorrentProvider):
         'baseurl': 'https://www.bitsoup.me/%s',
     }
 
+    cat_ids = [
+       ([41], ['720p', '1080p']),
+       ([19], ['cam', 'ts', 'tc', 'r5', 'scr', 'dvdrip', 'brrip']),
+       ([20], ['dvdr'])
+    ]
+
+    cat_backup_id = 0
     http_time_between_calls = 1 #seconds
 
     def _searchOnTitle(self, title, movie, quality, results):
 
         q = '"%s" %s' % (simplifyString(title), movie['library']['year'])
         arguments = tryUrlencode({
+            'cat': self.getCatId(quality['identifier'])[0],
             'search': q,
         })
         url = "%s&%s" % (self.urls['search'], arguments)


### PR DESCRIPTION
I've just noticed that the provider was actually failing to return any valid results whatsoever, leading to an AttributeError when trying to loop through result entries.

The following error was being logged:

```
12-28 11:32:47 ERROR [providers.torrent.bitsoup] Failed getting results from Bitsoup: Traceback (most recent call last):
  File "/volume1/@appstore/couchpotatoserver-custom/var/CouchPotatoServer/couchpotato/core/providers/torrent/bitsoup/main.py", line 38, in _searchOnTitle
    entries = result_table.find_all('tr')
AttributeError: 'NoneType' object has no attribute 'find_all'
```

There were no errors per se reported by the find() call itself, but essentially, as can be seen above, nothing was being found. This is despite the data being present on the 'html' variable.

Changing the BeautifulSoup parser from 'html5lib' to 'html.parser' appeared to "solve" the problem, but this was as far as my debugging went.

I'm not sure when this problem started happening.

While at it, I also added a category mapping to avoid some false positives I've been getting.
