### PR TITLE
BeautifulSoup not returning any data with html5lib and AttributeError when no results are found

### DIFF
--- a/couchpotato/core/providers/torrent/bitsoup/main.py
+++ b/couchpotato/core/providers/torrent/bitsoup/main.py
@@ -31,10 +31,13 @@ class Bitsoup(TorrentProvider):
         data = self.getHTMLData(url, opener = self.login_opener)
 
         if data:
-            html = BeautifulSoup(data)
+            html = BeautifulSoup(data, "html.parser")
 
             try:
                 result_table = html.find('table', attrs = {'class': 'koptekst'})
+                if not result_table or 'nothing found!' in data.lower():
+                    return
+
                 entries = result_table.find_all('tr')
                 for result in entries[1:]:
 


### PR DESCRIPTION
I've just noticed that the provider was actually failing to return any valid results whatsoever, leading to an AttributeError when trying to loop through result entries.

The following error was being logged:

```
12-28 11:32:47 ERROR [providers.torrent.bitsoup] Failed getting results from Bitsoup: Traceback (most recent call last):
  File "/volume1/@appstore/couchpotatoserver-custom/var/CouchPotatoServer/couchpotato/core/providers/torrent/bitsoup/main.py", line 38, in _searchOnTitle
    entries = result_table.find_all('tr')
AttributeError: 'NoneType' object has no attribute 'find_all'
```

There were no errors per se reported by the find() call itself, but essentially, as can be seen above, nothing was being found. This is despite the data being present on the 'html' variable.

Changing the BeautifulSoup parser from 'html5lib' to 'html.parser' appeared to "solve" the problem, but this was as far as my debugging went.

I'm not sure when this problem started happening.
