### PR TITLE
Library object has media instead of movies

### DIFF
--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -240,7 +240,7 @@ class Renamer(Plugin):
                 # Overwrite destination when set in category
                 destination = to_folder
                 category_label = ''
-                for movie in library_ent.movies:
+                for movie in library_ent.media:
 
                     if movie.category and movie.category.label:
                         category_label = movie.category.label
@@ -414,13 +414,13 @@ class Renamer(Plugin):
                 remove_leftovers = True
 
                 # Add it to the wanted list before we continue
-                if len(library_ent.movies) == 0:
+                if len(library_ent.media) == 0:
                     profile = db.query(Profile).filter_by(core = True, label = group['meta_data']['quality']['label']).first()
                     fireEvent('movie.add', params = {'identifier': group['library']['identifier'], 'profile_id': profile.id}, search_after = False)
                     db.expire_all()
                     library_ent = db.query(Library).filter_by(identifier = group['library']['identifier']).first()
 
-                for movie in library_ent.movies:
+                for movie in library_ent.media:
 
                     # Mark movie "done" once it's found the quality with the finish check
                     try:


### PR DESCRIPTION
Make the renamer work again by scanning the media instead of non-existent movies attribute in the library object (fixing error: AttributeError: 'Library' object has no attribute 'movies')
