### PR TITLE
Ensure quality is correct when updating an existing release

### DIFF
--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -384,6 +384,7 @@ class Release(Plugin):
                 db.add(rls)
             else:
                 [db.delete(old_info) for old_info in rls.info]
+                rls.quality_id = quality_type.get('quality_id')
                 rls.last_edit = int(time.time())
 
             db.commit()


### PR DESCRIPTION
The searcher can get into a "stuck" state if a release was previously identified as another quality, this can lead to the searcher re-snatching the same release every day.

I'm unsure why the release was previously identified as another quality, but this has happened to a few movies in my wanted list though.
