### PR TITLE
Fixed encoding bug with blackhole downloader

### DIFF
--- a/couchpotato/core/providers/base.py
+++ b/couchpotato/core/providers/base.py
@@ -164,7 +164,7 @@ class YarrProvider(Provider):
         try:
             if not self.login():
                 log.error('Failed downloading from %s', self.getName())
-            return self.urlopen(url)
+            return self.urlopen(url, return_raw = True)
         except:
             log.error('Failed downloading from %s: %s', (self.getName(), traceback.format_exc()))
 
@@ -173,7 +173,7 @@ class YarrProvider(Provider):
 
     def download(self, url = '', nzb_id = ''):
         try:
-            return self.urlopen(url, headers = {'User-Agent': Env.getIdentifier()}, show_error = False)
+            return self.urlopen(url, headers = {'User-Agent': Env.getIdentifier()}, show_error = False, return_raw = True)
         except:
             log.error('Failed getting nzb from %s: %s', (self.getName(), traceback.format_exc()))
 


### PR DESCRIPTION
The blackhole downloader can return a `UnicodeEncodeError` when saving some torrents. I narrowed this issue down to an encoding issue as a result of using the `.text` attribute from the download response when `.content` should be used (`return_raw = True` corrects this).

I'm not sure this encoding bug is limited to the blackhole downloader, it could be an issue for other downloaders.

**Note**
This fix could possibly break other downloaders as the change in `filedata` encoding might not be accepted by some of the downloaders. Do we need to test this on each downloader? or is there a better way we could handle this?
