### PR TITLE
Change 'modify date' after extracting rar-archive

### DIFF
--- a/couchpotato/core/plugins/renamer/__init__.py
+++ b/couchpotato/core/plugins/renamer/__init__.py
@@ -89,14 +89,6 @@ config = [{
                     'default': False,
                 },
                 {
-                    'advanced': True,
-                    'name': 'reset_file_date',
-                    'label': 'Reset file date',
-                    'type': 'bool',
-                    'description': 'Set modify date of all processed files to current date and time.',
-                    'default': False,
-                },
-                {
                     'name': 'cleanup',
                     'type': 'bool',
                     'description': 'Cleanup leftover files after successful rename.',

--- a/couchpotato/core/plugins/renamer/main.py
+++ b/couchpotato/core/plugins/renamer/main.py
@@ -761,12 +761,6 @@ Remove it if you want it to be renamed (again, or at least let it try again)
             except:
                 log.error('Failed setting permissions for file: %s, %s', (dest, traceback.format_exc(1)))
 
-            try:
-                if self.conf('reset_file_date'):
-                    os.utime(dest, None)
-            except:
-                log.error('Failed resetting date for file: %s, %s', (dest, traceback.format_exc(1)))
-
         except OSError, err:
             # Copying from a filesystem with octal permission to an NTFS file system causes a permission error.  In this case ignore it.
             if not hasattr(os, 'chmod') or err.errno != errno.EPERM:


### PR DESCRIPTION
Previously when extracting an archive, the modified date is kept the same as the file inside the archive. This commit changes the modified date to be the same as the rar-file's date.
- This makes xbmc correctly determine the movie as recently added
- It is more consistent with how other files are downloaded, as the modified date will be changed to the current time when downloading a file (over torrent/http etc.)
- Since we copy the modified date from the rar-file, the date is set as expected when renaming older files (as opposed to using the current time)
