### PR TITLE
Make Log messages pasteable

### DIFF
--- a/couchpotato/core/plugins/log/static/log.js
+++ b/couchpotato/core/plugins/log/static/log.js
@@ -73,10 +73,10 @@ Page.Log = new Class({
 			.replace(/\u001b\[31m/gi, '</span><span class="error">')
 			.replace(/\u001b\[36m/gi, '</span><span class="debug">')
 			.replace(/\u001b\[33m/gi, '</span><span class="debug">')
-			.replace(/\u001b\[0m\n/gi, '</span><span class="time">')
+			.replace(/\u001b\[0m\n/gi, '</span></div><div><span class="time">')
 			.replace(/\u001b\[0m/gi, '</span><span>')
 
-		return '<span class="time">' + text + '</span>';
+		return '<div><span class="time">' + text + '</span></div>';
 	}
 
 })


### PR DESCRIPTION
Currently log messages can't be copied and pasted from the log view without doing some manual editing. This patch adds a div element around each log line which in turn makes paste work properly for most browsers.
