### PR TITLE
Fixed bug in rTorrent downloader when file paths start with '/'

### DIFF
--- a/couchpotato/core/downloaders/rtorrent/main.py
+++ b/couchpotato/core/downloaders/rtorrent/main.py
@@ -173,9 +173,16 @@ class rTorrent(Downloader):
 
             for torrent in torrents:
                 if torrent.info_hash in ids:
+                    torrent_directory = os.path.normpath(torrent.directory)
                     torrent_files = []
-                    for file_item in torrent.get_files():
-                        torrent_files.append(sp(os.path.join(torrent.directory, file_item.path)))
+
+                    for file in torrent.get_files():
+                        if not os.path.normpath(file.path).startswith(torrent_directory):
+                            file_path = os.path.join(torrent_directory, file.path.lstrip('/'))
+                        else:
+                            file_path = file.path
+
+                        torrent_files.append(sp(file_path))
 
                     status = 'busy'
                     if torrent.complete:


### PR DESCRIPTION
Noticed that files from rTorrent sometimes start with `/`, this breaks `os.path.join` as it is interpreted as an absolute path when it's actually relative. This issue leads to the renamer failing to find the files, so never processes the movie.

This should fix this issue by stripping the starting `/` if the path is truly relative (doesn't start with `torrent.directory`).
