### PR TITLE
Fix rTorrent connectivity

### DIFF
--- a/couchpotato/core/downloaders/rtorrent/main.py
+++ b/couchpotato/core/downloaders/rtorrent/main.py
@@ -42,7 +42,7 @@ class rTorrent(Downloader):
         if self.rt is not None:
             return self.rt
 
-        url = cleanHost(self.conf('host'), protocol = True, ssl = self.conf('ssl')) + '/' + self.conf('rpc_url').strip('/ ') + '/'
+        url = cleanHost(self.conf('host'), protocol = True, ssl = self.conf('ssl')) + self.conf('rpc_url')
 
         if self.conf('username') and self.conf('password'):
             self.rt = RTorrent(

--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -136,9 +136,25 @@ def getExt(filename):
 
 
 def cleanHost(host, protocol = True, ssl = False, username = None, password = None):
+    """Return a cleaned up host with given url options set
+
+    Changes protocol to https if ssl is set to True and http if ssl is set to false.
+    >>> cleanHost("localhost:80", ssl=True)
+    'https://localhost:80/'
+    >>> cleanHost("localhost:80", ssl=False)
+    'http://localhost:80/'
+
+    Username and password is managed with the username and password variables
+    >>> cleanHost("localhost:80", username="user", password="passwd")
+    'http://user:passwd@localhost:80/'
+
+    Output without scheme (protocol) can be forced with protocol=False
+    >>> cleanHost("localhost:80", protocol=False)
+    'localhost:80'
+    """
 
     if not '://' in host and protocol:
-        host = 'https://' if ssl else 'http://' + host
+        host = ('https://' if ssl else 'http://') + host
 
     if not protocol:
         host = host.split('://', 1)[-1]


### PR DESCRIPTION
The combination of cleanHost and rTorrent.connect issues caused rTorrent
connections to fail. This update fixes cleanHost() so that it can
actually cope with SSL based hosts and finishes the migration to
cleanHost() in connect()

This also adds a doctest to cleanHost to avoid running in to this issue in the future.
