### PR TITLE
Update the proxy domians

### DIFF
--- a/couchpotato/core/providers/torrent/yify/main.py
+++ b/couchpotato/core/providers/torrent/yify/main.py
@@ -17,7 +17,7 @@ class Yify(TorrentMagnetProvider):
     http_time_between_calls = 1 #seconds
     
     proxy_list = [
-        'http://static.yts.re.prx2.unblocksit.es/',
+        'http://static.yts.re.prx2.unblocksit.es',
            ]
 
     def search(self, movie, quality):


### PR DESCRIPTION
The site admin of YIFY has changed the back end and changed owners from the looks of it he is blocking other Vhosts. Most/all proxy sites are now broken and will alway point to a blocked URL, I have removed the blocked links and replace them with the new proxy link.
