### PR TITLE
Fix IPT provider

### DIFF
--- a/couchpotato/core/providers/torrent/iptorrents/main.py
+++ b/couchpotato/core/providers/torrent/iptorrents/main.py
@@ -99,7 +99,10 @@ class IPTorrents(TorrentProvider):
         result = {}
 
         for x, col in enumerate(entries[0].find_all('th')):
-            key = toSafeString(col.text).strip().lower()
+            content = col.string
+            if content == None:
+                content = col.find_all('img')[0].get('alt', '')
+            key = toSafeString(content).strip().lower()
 
             if not key:
                 continue


### PR DESCRIPTION
This is an attempt to fix #2777 - table unrecognized errors.

`.string` and `.text` don't return anything except strings.
Since seeder and leecher column headers are represented by images/icons
in stead of text, snap the column header from the img alt tags.
