### PR TITLE
[SceneAccess] Change search method to 3 (description)

### DIFF
--- a/couchpotato/core/providers/torrent/sceneaccess/main.py
+++ b/couchpotato/core/providers/torrent/sceneaccess/main.py
@@ -40,7 +40,7 @@ class SceneAccess(TorrentProvider):
 
         arguments = tryUrlencode({
             'search': movie['library']['identifier'],
-            'method': 1,
+            'method': 3,
         })
         url = "%s&%s" % (url, arguments)
 


### PR DESCRIPTION
CouchPotato couldn't find any movies on the advanced search option in SceneAccess. I changed the search option to description (method 3) and now the provider is working correctly again. 
