### PR TITLE
[rtorrent] Fixed naming issue

### DIFF
--- a/couchpotato/core/downloaders/rtorrent/main.py
+++ b/couchpotato/core/downloaders/rtorrent/main.py
@@ -87,7 +87,7 @@ class rTorrent(Downloader):
 
         return False
 
-    def _update_provider_group(self, name, data):
+    def updateProviderGroup(self, name, data):
         if data.get('seed_time'):
             log.info('seeding time ignored, not supported')
 


### PR DESCRIPTION
Not sure how this bug got into here, this function is referenced at [rtorrent/main.py#L139](https://github.com/fuzeman/CouchPotatoServer/blob/9056f5ae59dfde6a479d2b962b869647043f9ba3/couchpotato/core/downloaders/rtorrent/main.py#L139) but under the correct name. Looks like this bug made it into master as well.
