### PR TITLE
Fixed invalid variable reference in socket error handling

### DIFF
--- a/CouchPotato.py
+++ b/CouchPotato.py
@@ -136,7 +136,7 @@ if __name__ == '__main__':
     except socket.error as e:
         # log when socket receives SIGINT, but continue.
         # previous code would have skipped over other types of IO errors too.
-        if nr != 4:
+        if e != 4:
             try:
                 l.log.critical(traceback.format_exc())
             except:


### PR DESCRIPTION
[Code cleanup](https://github.com/RuudBurger/CouchPotatoServer/commit/799299c7ccc63e02bd958e0562a251814a094cef) changed the assigned name of a socket.error, but the old name is still referenced in the code, causing a fatal error when CouchPotato tries to log socket issues.
