### PR TITLE
Add "CouchPotato - " to the Notification Title

### DIFF
--- a/couchpotato/core/notifications/boxcar2/main.py
+++ b/couchpotato/core/notifications/boxcar2/main.py
@@ -23,7 +23,7 @@ class Boxcar2(Notification):
 
             data = {
                 'user_credentials': self.conf('token'),
-                'notification[title]': toUnicode(message),
+                'notification[title]': "CouchPotato - " + toUnicode(message),
                 'notification[long_message]': toUnicode(long_message),
             }
 


### PR DESCRIPTION
Boxcar2 no longer puts the Service Name in the Notification. When the notification comes through to the iPhone it is hard to tell what service this is coming from.

I have added "CouchPotato - " to the notification, so it looks similar to the old style Boxcar notifications.
