### PR TITLE
Added custom sounds ability to Pushover Advanced Settings

### DIFF
--- a/couchpotato/core/notifications/pushover.py
+++ b/couchpotato/core/notifications/pushover.py
@@ -88,7 +88,6 @@ config = [{
                     'advanced': True,
                     'description': 'Define <a href="https://pushover.net/api%23sounds" target="_blank">custom sound</a> for Pushover alert.'
                 },
-
             ],
         }
     ],


### PR DESCRIPTION
Added a txtbox in Advanced Settings for Pushover iOS notification app to allow for the selection of custom sounds. A hyperlink to the list of available sounds is in the description of the txtbox. If the user types nothing into the txtbox or any combination of characters which are not on the Pushover API sound list, the notification will be sent using the default Pushover sound.

Thanks
