### PR TITLE
Fix false positives from SceneAccess

### DIFF
--- a/couchpotato/core/media/movie/providers/torrent/sceneaccess.py
+++ b/couchpotato/core/media/movie/providers/torrent/sceneaccess.py
@@ -23,7 +23,7 @@ class SceneAccess(MovieProvider, Base):
 
         arguments = tryUrlencode({
             'search': fireEvent('library.query', media, single = True),
-            'method': 3,
+            'method': 2,
         })
         query = "%s&%s" % (url, arguments)
 


### PR DESCRIPTION
I've gotten a lot of false positives from SceneAccess lately. I'm not sure if this was changed recently, but now 'Method:3' searches the description of a torrent. 'Method:2' now searches title, which I guess is the preferred method?
