### PR TITLE
Avoid duplicate subtitle language identifier

### DIFF
--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -412,8 +412,12 @@ class Renamer(Plugin):
 
                             # Don't add language if multiple languages in 1 subtitle file
                             if len(sub_langs) == 1:
-                                sub_name = sub_name.replace(replacements['ext'], '%s.%s' % (sub_langs[0], replacements['ext']))
-                                rename_files[current_file] = os.path.join(destination, final_folder_name, sub_name)
+                                sub_suffix = '%s.%s' % (sub_langs[0], replacements['ext'])
+
+                                # Don't add language to subtitle file it it's already there
+                                if not sub_name.endswith(sub_suffix):
+                                    sub_name = sub_name.replace(replacements['ext'], sub_suffix)
+                                    rename_files[current_file] = os.path.join(destination, final_folder_name, sub_name)
 
                             rename_files = mergeDicts(rename_files, rename_extras)
 


### PR DESCRIPTION
CouchPotato currently adds the subtitle language identifier to the subtitle file name to identify the subtitle language if multiple subtitles were downloaded. However, Subliminal also does this by default. The current CP behavior will lead to duplicate subtitle language identifiers in the subtitle file name.

This commit prevents that by checking if the identifier is already there. If it's not, CP will add it as usual.
