### PR TITLE
Fix false positives from Sceneaccess and Torrentday

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/sceneaccess.py
+++ b/couchpotato/core/media/_base/providers/torrent/sceneaccess.py
@@ -24,9 +24,9 @@ class Base(TorrentProvider):
 
     http_time_between_calls = 1  # Seconds
 
-    def _search(self, media, quality, results):
+    def _searchOnTitle(self, title, media, quality, results):
 
-        url = self.buildUrl(media, quality)
+        url = self.buildUrl(title, media, quality)
         data = self.getHTMLData(url)
 
         if data:

--- a/couchpotato/core/media/_base/providers/torrent/torrentday.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentday.py
@@ -1,3 +1,4 @@
+from couchpotato.core.helpers.encoding import tryUrlencode
 from couchpotato.core.helpers.variable import tryInt
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media._base.providers.torrent.base import TorrentProvider
@@ -18,16 +19,16 @@ class Base(TorrentProvider):
 
     http_time_between_calls = 1  # Seconds
 
-    def _search(self, media, quality, results):
+    def _searchOnTitle(self, title, media, quality, results):
 
-        query = self.buildUrl(media)
+        query = '%s %s' % (title, media['info']['year'])
 
         data = {
             '/browse.php?': None,
             'cata': 'yes',
             'jxt': 8,
             'jxw': 'b',
-            'search': query,
+            'search': tryUrlencode(query),
         }
 
         data = self.getJsonData(self.urls['search'], data = data)

--- a/couchpotato/core/media/movie/providers/torrent/sceneaccess.py
+++ b/couchpotato/core/media/movie/providers/torrent/sceneaccess.py
@@ -17,13 +17,13 @@ class SceneAccess(MovieProvider, Base):
         ([8], ['dvdr']),
     ]
 
-    def buildUrl(self, media, quality):
+    def buildUrl(self, title, media, quality):
         cat_id = self.getCatId(quality)[0]
         url = self.urls['search'] % (cat_id, cat_id)
 
         arguments = tryUrlencode({
-            'search': fireEvent('library.query', media, single = True),
-            'method': 3,
+            'search': '%s %s' % (title, media['info']['year']),
+            'method': 2,
         })
         query = "%s&%s" % (url, arguments)
 


### PR DESCRIPTION
Seems to work much better now from the brief testing I have done.

I don't really understand the purpose of having two functions though, one called search and one called searchOnTitle? It seems most of the providers use the search-function, but if I understood correct, they should all use the searchOnTitle function instead?

Also, why are the buildUrl-functions put in that ... other file (not in the base folder) for all the providers?
