### PR TITLE
Fix searches on torrentday and sceneaccess

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/torrentday.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentday.py
@@ -28,7 +28,7 @@ class Base(TorrentProvider):
             'cata': 'yes',
             'jxt': 8,
             'jxw': 'b',
-            'search': tryUrlencode(query),
+            'search': query,
         }
 
         data = self.getJsonData(self.urls['search'], data = data)

--- a/couchpotato/core/media/movie/providers/torrent/sceneaccess.py
+++ b/couchpotato/core/media/movie/providers/torrent/sceneaccess.py
@@ -22,7 +22,7 @@ class SceneAccess(MovieProvider, Base):
         url = self.urls['search'] % (cat_id, cat_id)
 
         arguments = tryUrlencode({
-            'search': '"%s" %s' % (title, media['info']['year']),
+            'search': '%s %s' % (title, media['info']['year']),
             'method': 2,
         })
         query = "%s&%s" % (url, arguments)


### PR DESCRIPTION
Quotes in search query does not work as expected on Sceneaccess (returns no results).
For torrentday, search query should not be urlencoded as this is done already in subfunction (returned no results before when using quotes).
