### PR TITLE
Added regex support to global filters to help combat fakes

### DIFF
--- a/couchpotato/core/media/_base/searcher/main.py
+++ b/couchpotato/core/media/_base/searcher/main.py
@@ -188,8 +188,12 @@ class Searcher(SearcherBase):
 
         req_match = 0
         for req_set in required_words:
-            req = splitString(req_set, '&')
-            req_match += len(list(set(rel_words) & set(req))) == len(req)
+            if len(req_set) >= 2 and (req_set[:1] + req_set[-1:]) == '//':
+                if re.search(req_set[1:-1], rel_name):
+                    req_match += 1
+            else:
+                req = splitString(req_set, '&')
+                req_match += len(list(set(rel_words) & set(req))) == len(req)
 
         if len(required_words) > 0 and req_match == 0:
             log.info2('Wrong: Required word missing: %s', rel_name)
@@ -202,8 +206,12 @@ class Searcher(SearcherBase):
 
         ignored_match = 0
         for ignored_set in ignored_words:
-            ignored = splitString(ignored_set, '&')
-            ignored_match += len(list(set(rel_words) & set(ignored))) == len(ignored)
+            if len(ignored_set) >= 2 and (ignored_set[:1] + ignored_set[-1:]) == '//':
+                if re.search(ignored_set[1:-1], rel_name):
+                    ignored_match += 1
+            else:
+                ignored = splitString(ignored_set, '&')
+                ignored_match += len(list(set(rel_words) & set(ignored))) == len(ignored)
 
         if len(ignored_words) > 0 and ignored_match:
             log.info2("Wrong: '%s' contains 'ignored words'", rel_name)


### PR DESCRIPTION
I put in a rule for global filters that lets required & ignored filters contain regexs if the start and end with / 
I tested it and its working for my build .. I didnt add any documentation nor did i add support for categories .. the pull request is for the latest as of today .. im new to github collab so let me know if i did something wrong :)
I have a regex that seems to work pretty good with the current fakes that are being released .. Let me know if you want a copy.

I messed up my last pull request so this is another attempt at it
