### PR TITLE
Making small changes to Fedora systemd unit

### DIFF
--- a/init/couchpotato.fedora.service
+++ b/init/couchpotato.fedora.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=CouchPotato application instance
+After=network.target
 
 [Service]
-ExecStart=/usr/lib/CouchPotatoServer/CouchPotato.py --daemon 
+ExecStart=/var/lib/CouchPotatoServer/CouchPotato.py --daemon 
 GuessMainPID=no
 Type=forking
 User=couchpotato


### PR DESCRIPTION
Adding a dependency to the network.target. Changing couchpotato directory from '/usr/lib/' to '/var/lib' per the FHS. This isn't "right" per se and obviously the user can put CP wherever they want but this "suggestion" seems a little more sensible.
