### PR TITLE
Removed hard-coded pushover API key as per Pushover developers advice

### DIFF
--- a/couchpotato/core/notifications/pushover.py
+++ b/couchpotato/core/notifications/pushover.py
@@ -13,7 +13,6 @@ autoload = 'Pushover'
 
 class Pushover(Notification):
 
-    app_token = 'YkxHMYDZp285L265L3IwH3LmzkTaCy'
 
     def notify(self, message = '', data = None, listener = None):
         if not data: data = {}
@@ -22,7 +21,7 @@ class Pushover(Notification):
 
         api_data = {
             'user': self.conf('user_key'),
-            'token': self.app_token,
+            'token': self.conf('api_token'),
             'message': toUnicode(message),
             'priority': self.conf('priority'),
             'sound': self.conf('sound'),
@@ -69,6 +68,10 @@ config = [{
                 {
                     'name': 'user_key',
                     'description': 'Register on pushover.net to get one.'
+                },
+				{
+                    'name': 'api_token',
+                    'description': '<a href="https://pushover.net/apps/clone/couchpotato" target="_blank">Register on pushover.net</a> to get one.'
                 },
                 {
                     'name': 'priority',


### PR DESCRIPTION
See: https://github.com/echel0n/SickRage/pull/604

@jcs, the Pushover developer advised that the Pushover API token should not be hard-coded into any application. The link added into the config screen allows users to register an API key with the couchpotato logo etc. within 2 button clicks (if logged in). 

It also has the added benefit of each user being able to view stats for how many messages are sent from their couchpotato each day and gives everyone a 7,500 message limit instead of sharing 1 key.
