### PR TITLE
Finish non-existent API calls instead of timing out

### DIFF
--- a/couchpotato/api.py
+++ b/couchpotato/api.py
@@ -89,6 +89,7 @@ class ApiHandler(RequestHandler):
         route = route.strip('/')
         if not api.get(route):
             self.write('API call doesn\'t seem to exist')
+            self.finish()
             return
 
         # Create lock if it doesn't exist


### PR DESCRIPTION
Running a non-existent API query causes a time out instead of presenting an error.
