### PR TITLE
Update iptorrents.py

### DIFF
--- a/couchpotato/core/media/movie/providers/torrent/iptorrents.py
+++ b/couchpotato/core/media/movie/providers/torrent/iptorrents.py
@@ -13,7 +13,7 @@ class IPTorrents(MovieProvider, Base):
         ([87], ['3d']),
         ([48], ['720p', '1080p', 'bd50']),
         ([72], ['cam', 'ts', 'tc', 'r5', 'scr']),
-        ([7], ['dvdrip', 'brrip']),
+        ([48], ['dvdrip', 'brrip']),
         ([6], ['dvdr']),
     ]
 


### PR DESCRIPTION
Change the category for dvdrip and brrip on IPtorrents.  See the following thread for more info:

https://couchpota.to/forum/viewtopic.php?f=5&t=4032&sid=7892abbaaca9dad8bd3cc27cafb7fd33
