### PR TITLE
Give higher weight to freeleech torrents

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/passthepopcorn.py
+++ b/couchpotato/core/media/_base/providers/torrent/passthepopcorn.py
@@ -64,6 +64,10 @@ class Base(TorrentProvider):
                         torrentdesc += ' HQ'
                         if self.conf('prefer_golden'):
                             torrentscore += 5000
+                    if 'FreeleechType' in torrent:
+                        torrentdesc += ' Freeleech'
+                        if self.conf('prefer_freeleech'):
+                            torrentscore += 7000
                     if 'Scene' in torrent and torrent['Scene']:
                         torrentdesc += ' Scene'
                         if self.conf('prefer_scene'):
@@ -222,6 +226,14 @@ config = [{
                     'label': 'Prefer golden',
                     'default': 1,
                     'description': 'Favors Golden Popcorn-releases over all other releases.'
+                },
+                {
+                    'name': 'prefer_freeleech',
+                    'advanced': True,
+                    'type': 'bool',
+                    'label': 'Prefer Freeleech',
+                    'default': 1,
+                    'description': 'Favors torrents marked as freeleech over all other releases.'
                 },
                 {
                     'name': 'prefer_scene',


### PR DESCRIPTION
Freeleech was previously ignored, and caused a golden torrent to get priority over the freeleech.

I set the score to +7000 for freeleech (vs +5000 for golden) -- I'm not sure what is best since it is not particularly clear which one would win in a tie breaker. Perhaps it would be better to change these options to "Bonus for Freeleech", and allow the user to enter a number? Since it is already enabled by default, we could just default to the current values.

Also, as a side note: I am not explicitly checking what the Value of FreeleechType is since it only shows up if the torrent is marked freeleech. I am not sure what the syntax of things like halfleech and neutral leech is (none available at the moment).
