### PR TITLE
runner.py can handle stray directories in backup_path

### DIFF
--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -9,6 +9,7 @@ import traceback
 import warnings
 import re
 import tarfile
+import shutil
 
 from CodernityDB.database_super_thread_safe import SuperThreadSafeDatabase
 from argparse import ArgumentParser
@@ -108,14 +109,19 @@ def runCouchPotato(options, base_path, args, data_dir = None, log_dir = None, En
         if not os.path.isdir(backup_path): os.makedirs(backup_path)
 
         for root, dirs, files in os.walk(backup_path):
-            for backup_file in sorted(files):
-                ints = re.findall('\d+', backup_file)
+            # Only consider files being a direct child of the backup_path
+            if root == backup_path:
+                for backup_file in sorted(files):
+                    ints = re.findall('\d+', backup_file)
 
-                # Delete non zip files
-                if len(ints) != 1:
-                    os.remove(os.path.join(backup_path, backup_file))
-                else:
-                    existing_backups.append((int(ints[0]), backup_file))
+                    # Delete non zip files
+                    if len(ints) != 1:
+                        os.remove(os.path.join(root, backup_file))
+                    else:
+                        existing_backups.append((int(ints[0]), backup_file))
+            else:
+                # Delete stray directories.
+                shutil.rmtree(root)
 
         # Remove all but the last 5
         for eb in existing_backups[:-backup_count]:


### PR DESCRIPTION
Remove directories as part of cleaning up old database backups. This prevents the cleanup routine from trying to remove files residing in a sub directory of the backup path.
