### PR TITLE
Fix for Issue #4145 - Search doesn't look for 'unknown' quality for Kickass Torrent Provider

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
@@ -21,7 +21,7 @@ class Base(TorrentMagnetProvider):
         (['cam'], ['cam']),
         (['telesync'], ['ts', 'tc']),
         (['screener', 'tvrip'], ['screener']),
-        (['x264', '720p', '1080p', 'blu-ray', 'hdrip'], ['bd50', '1080p', '720p', 'brrip']),
+        (['x264', '720p', '1080p', 'blu-ray', 'hdrip', 'unknown'], ['bd50', '1080p', '720p', 'brrip']),
         (['dvdrip'], ['dvdrip']),
         (['dvd'], ['dvdr']),
     ]


### PR DESCRIPTION
Added the 'unknown' keyword to the cat_ids list.
