### PR TITLE
adding a fix to handle missing directories in the file browser in webkit browsers

### DIFF
--- a/couchpotato/static/scripts/page/settings.js
+++ b/couchpotato/static/scripts/page/settings.js
@@ -885,7 +885,10 @@ Option.Directory = new Class({
 			new Element('li.empty', {
 				'text': 'Selected folder is empty'
 			}).inject(self.dir_list)
-
+			
+		//fix for webkit type browsers to refresh the dom for the file browser
+		//http://stackoverflow.com/questions/3485365/how-can-i-force-webkit-to-redraw-repaint-to-propagate-style-changes
+		self.dir_list.setStyle("webkitTransform", "scale(1)")
 		self.caretAtEnd();
 	},
 


### PR DESCRIPTION
On webkit browsers, the file directory browser does not display items sometimes due to a weird issue with the dom refreshes. Anyway, I fixed the issue by generating a fake scaling in the menu. This issue is happening on my mac in chrome and safari. Instead of creating a ticket I thought I'd fix it :) See the image I attached for what the problem was.

![screen shot 2014-11-10 at 7 04 59 pm](https://cloud.githubusercontent.com/assets/775255/4986854/accb5eca-6941-11e4-84bb-90f481d04a41.png)
