### PR TITLE
Added renamer.progress API function. Fixes #4211.

### DIFF
--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -44,6 +44,13 @@ class Renamer(Plugin):
             },
         })
 
+        addApiView('renamer.progress', self.getProgress, docs = {
+            'desc': 'Get the progress of current renamer scan',
+            'return': {'type': 'object', 'example': """{
+    'progress': False || True,
+}"""},
+        })
+
         addEvent('renamer.scan', self.scan)
         addEvent('renamer.check_snatched', self.checkSnatched)
 
@@ -66,6 +73,11 @@ class Renamer(Plugin):
             fireEvent('schedule.interval', 'renamer.check_snatched_forced', self.scan, hours = self.conf('force_every'), single = True)
 
         return True
+
+    def getProgress(self, **kwargs):
+        return {
+            'progress': self.renaming_started
+        }
 
     def scanView(self, **kwargs):
 


### PR DESCRIPTION
This function reports the status of the renamer.
Progress value True means the renamer is currently running.
Progress value False means the renamer is not currently running.
