### PR TITLE
Update Kickass url to https://kickass.so

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
@@ -30,7 +30,7 @@ class Base(TorrentMagnetProvider):
     cat_backup_id = None
 
     proxy_list = [
-        'https://kickass.to',
+        'https://kickass.so',
         'http://kickass.pw',
         'http://kickassto.come.in',
         'http://katproxy.ws',


### PR DESCRIPTION
Kickass has recently changed its web address from https://kickass.to 
to https://kickass.so
