### PR TITLE
Updated Plex Notification Support

### DIFF
--- a/couchpotato/core/notifications/plex/__init__.py
+++ b/couchpotato/core/notifications/plex/__init__.py
@@ -24,6 +24,12 @@ config = [{
                     'description': 'Hostname/IP, default localhost'
                 },
                 {
+                    'name': 'auth_token',
+                    'label': 'Auth Token',
+                    'default': '',
+                    'description': 'Required for myPlex'
+                },
+                {
                     'name': 'clients',
                     'default': '',
                     'description': 'Comma separated list of client names\'s (computer names). Top right when you start Plex'

--- a/couchpotato/core/notifications/plex/server.py
+++ b/couchpotato/core/notifications/plex/server.py
@@ -35,11 +35,20 @@ class PlexServer(object):
         if path.startswith('/'):
             path = path[1:]
 
-        data = self.plex.urlopen('%s/%s' % (
-            self.createHost(self.plex.conf('media_server'), port = 32400),
-            path
-        ))
-
+        #Maintain support for older Plex installations without myPlex
+        if not self.plex.conf('auth_token'):
+            data = self.plex.urlopen('%s/%s' % (
+                self.createHost(self.plex.conf('media_server'), port = 32400),
+                path
+            ))
+        else:
+            #Add X-Plex-Token header for myPlex support workaround
+            data = self.plex.urlopen('%s/%s?X-Plex-Token=%s' % (
+                self.createHost(self.plex.conf('media_server'), port = 32400),
+                path,
+                self.plex.conf('auth_token')
+            ))
+        
         if data_type == 'xml':
             return etree.fromstring(data)
         else:


### PR DESCRIPTION
Workaround for https://github.com/RuudBurger/CouchPotatoServer/issues/4239
Workaround for https://github.com/RuudBurger/CouchPotatoServer/issues/3303

Added basic support for myPlex via Authentication Token. This is a
workaround until myPlex login via username/password is implemented.

Authentication Token can be obtained by:
```
curl -H "Content-Length: 0" -H "X-Plex-Client-Identifier: my-app" --user "myPlexUsername:myPlexPassword" -X POST https://my.plexapp.com/users/sign_in.xml
```
The resulting XML will have your myPlex Authentication Token
```
<?xml version="1.0" encoding="UTF-8"?>
  <subscription active="1" status="Active" plan="lifetime">
    <feature id="pass"/>
    <feature id="sync"/>
    <feature id="cloudsync"/>
  </subscription>
  <roles>
    <role id="plexpass"/>
  </roles>
  <entitlements all="1">
    <entitlement id="roku"/>
    <entitlement id="android"/>
    <entitlement id="xbox_one"/>
    <entitlement id="xbox_360"/>
  </entitlements>
  <username>wolfienuke</username>
  <email>wolfienuke@hotmail.com</email>
  <joined-at type="datetime">2000-00-00 00:00:00 UTC</joined-at>
  <authentication-token>XXxXXxXXxXXXXXxXxxXx</authentication-token>
</user>
```
I will update soon (after finals are complete) with a proper Login/Password solution for myPlex