### PR TITLE
Change Readd to Re-add, former might be misread as a typo for Read

### DIFF
--- a/couchpotato/core/media/movie/_base/static/movie.actions.js
+++ b/couchpotato/core/media/movie/_base/static/movie.actions.js
@@ -696,7 +696,7 @@ MA.Readd = new Class({
 
 		if(movie_done || snatched && snatched > 0)
 			self.el = new Element('a.readd', {
-				'title': 'Readd the movie and mark all previous snatched/downloaded as ignored',
+				'title': 'Re-add the movie and mark all previous snatched/downloaded as ignored',
 				'events': {
 					'click': self.doReadd.bind(self)
 				}


### PR DESCRIPTION
New to CP, started yesterday. The tooltip for this option was confusing to me, seeing the word "Readd" I instinctively thought it was a typo for "Read." It didn't make sense to "Read the movie" on a webserver either.
