### PR TITLE
Change Readd in tooltip to Re-add. Former is confusing and not an Englis...

### DIFF
--- a/couchpotato/core/media/movie/_base/static/movie.actions.js
+++ b/couchpotato/core/media/movie/_base/static/movie.actions.js
@@ -696,7 +696,7 @@ MA.Readd = new Class({
 
 		if(movie_done || snatched && snatched > 0)
 			self.el = new Element('a.readd', {
-				'title': 'Readd the movie and mark all previous snatched/downloaded as ignored',
+				'title': 'Re-add the movie and mark all previous snatched/downloaded as ignored',
 				'events': {
 					'click': self.doReadd.bind(self)
 				}


### PR DESCRIPTION
I am a new user of CP, the tooltip int he manage section for re-adding was confusing. I thought it was a typo for the word read.

Changed from
Readd to Re-add
