### PR TITLE
Initial support for Plex Media Server w/Plex Home

### DIFF
--- a/couchpotato/core/notifications/plex/__init__.py
+++ b/couchpotato/core/notifications/plex/__init__.py
@@ -24,6 +24,26 @@ config = [{
                     'description': 'Hostname/IP, default localhost'
                 },
                 {
+                    'name': 'username',
+                    'label': 'Username',
+                    'default': '',
+                    'description': 'Required for myPlex'
+                },
+                {
+                    'name': 'password',
+                    'label': 'Password',
+                    'default': '',
+                    'type': 'password',
+                    'description': 'Required for myPlex'
+                },
+                {
+                    'name': 'auth_token',
+                    'label': 'Auth Token',
+                    'default': '',
+                    'advanced': True,
+                    'description': 'Required for myPlex'
+                },
+                {
                     'name': 'clients',
                     'default': '',
                     'description': 'Comma separated list of client names\'s (computer names). Top right when you start Plex'


### PR DESCRIPTION
Based on #4328 and fixes #4239, but supports fetching the authentication token using username/password while still being able to use just an auth token if you want.