### PR TITLE
the pidfile should exist and be writable by the daemon

### DIFF
--- a/init/ubuntu
+++ b/init/ubuntu
@@ -95,6 +95,8 @@ fi
 
 case "$1" in
   start)
+        touch $PID_FILE
+        chown $RUN_AS $PID_FILE
         echo "Starting $DESC"
         start-stop-daemon -d $APP_PATH -c $RUN_AS $EXTRA_SSD_OPTS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
         ;;


### PR DESCRIPTION
Found this to be broken on a fresh install on ubuntu trusty (14.04)

It starts but "status", "stop" etc fail because the daemon can't update the $PID_FILE after being launched.

The pid file must be +rw to the daemon as start-stop-daemon (although it can create the file) does not address the ownership I think.

Works with  PID_FILE=/var/run/couchpotato/couchpotato.pid