### PR TITLE
added touch and chown to the $PID_FILE

### DIFF
--- a/init/ubuntu
+++ b/init/ubuntu
@@ -95,6 +95,8 @@ fi
 
 case "$1" in
   start)
+        touch $PID_FILE
+        chown $RUN_AS $PID_FILE
         echo "Starting $DESC"
         start-stop-daemon -d $APP_PATH -c $RUN_AS $EXTRA_SSD_OPTS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
         ;;


### PR DESCRIPTION
There is currently a problem where Ubuntu's "start-stop-daemon" may create these files (with ```-m``` IIRC) but it doesn't on default... In addition if the service start does create these it uses the PID of the inital CP fork not the actual live running pid.


..as a result ```service couchpotato status```  (and ```service couchpotato stop``` ; ```service couchpotato restart``` presumably) is broken on ubuntu 14.04 and no doubt others also.  (My install path was /opt/couchpotato

CP appears to update this ```$PID_FILE``` once running but on top of the file existing it should also be +rw by the CP process (so checks to ensure it can write the that folder would be wise down the line I guess)

Anyways sorry for the multiple failed attempts to get this upstream, I'm brand new to git branches.

I've tested with these VAR from ```/etc/default/couchpotato```
```
CP_HOME=/opt/couchpotato/.couchpotato
CP_USER=couchpotato
CP_DATA=/opt/couchpotato/.couchpotato/data
CP_PIDFILE=/var/run/couchpotato.pid
PYTHON_BIN=/usr/bin/python2.7
CP_OPTS=--config_file=/opt/couchpotato/config.ini
```
Regards -david