### PR TITLE
Simple workaround for #2782

### DIFF
--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -885,7 +885,9 @@ Remove it if you want it to be renamed (again, or at least let it try again)
                 #If information is not available, we don't want the tag in the filename
                 replaced = replaced.replace('<' + x + '>', '')
 
-        replaced = self.replaceDoubles(replaced.lstrip('. '))
+        if self.conf('replace_doubles'):
+           replaced = self.replaceDoubles(replaced.lstrip('. '))       
+        
         for x, r in replacements.items():
             if x in ['thename', 'namethe']:
                 replaced = replaced.replace(six.u('<%s>') % toUnicode(x), toUnicode(r))
@@ -1341,6 +1343,14 @@ config = [{
                     'default': '<thename><cd>.<ext>',
                     'type': 'choice',
                     'options': rename_options
+                },
+                {
+                    'advanced': True,                
+                    'name': 'replace_doubles',
+                    'type': 'bool',
+                    'label': 'Consider Missing Data',
+                    'description': 'Attempt to clean up double separaters due to missing data for fields',
+                    'default': True 
                 },
                 {
                     'name': 'unrar',

--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -1348,8 +1348,8 @@ config = [{
                     'advanced': True,                
                     'name': 'replace_doubles',
                     'type': 'bool',
-                    'label': 'Consider Missing Data',
-                    'description': 'Attempt to clean up double separaters due to missing data for fields',
+                    'label': 'Clean Name',
+                    'description': ('Attempt to clean up double separaters due to missing data for fields.','Sometimes this eliminates wanted white space (see <a href="https://github.com/RuudBurger/CouchPotatoServer/issues/2782">#2782</a>).'),
                     'default': True 
                 },
                 {


### PR DESCRIPTION
See #2782.

This creates a new advanced option that disables the replaceDoubles feature that causes the issue.

Until there is a more elegant solution to avoid unwanted white space
trimming, this will let users disable that feature if it is not
something they need. (for example, if just using title and year, i think it is safe to assume those will always exist)

* Make sure your pull request is made for the develop branch (or relevant feature branch). - *CouchPotatoBot doesn't seem to think so (not checked) but it looks right to me. Let me know if I need to do it differently.*
* Have you tested your PR? If not, why? - *Yes I have tested it locally in Win8/Chrome.*
* Does your PR have any limitations I should know of? - *Obviously disabling the feature means CP will no longer clean up duplicated separators due to missing data.*
* Is your PR up-to-date with the branch you're trying to push into? - *Yes.*