### PR TITLE
Update kickass url from kickass.so to kickass.to

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
@@ -30,7 +30,7 @@ class Base(TorrentMagnetProvider):
     cat_backup_id = None
 
     proxy_list = [
-        'https://kickass.so',
+        'https://kickass.to',
         'http://kickass.pw',
         'http://kickassto.come.in',
         'http://katproxy.ws',


### PR DESCRIPTION
Kickass has reverted back to the .to domain as the .so domain was seized:
http://torrentfreak.com/kickasstorrents-taken-domain-name-seizure-150209/