### PR TITLE
Update torrentshack with new URL

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/torrentshack.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentshack.py
@@ -13,12 +13,12 @@ log = CPLog(__name__)
 class Base(TorrentProvider):
 
     urls = {
-        'test': 'http://torrentshack.eu/',
-        'login': 'http://torrentshack.eu/login.php',
-        'login_check': 'http://torrentshack.eu/inbox.php',
-        'detail': 'http://torrentshack.eu/torrent/%s',
-        'search': 'http://torrentshack.eu/torrents.php?action=advanced&searchstr=%s&scene=%s&filter_cat[%d]=1',
-        'download': 'http://torrentshack.eu/%s',
+        'test': 'https://theshack.us.to/',
+        'login': 'https://theshack.us.to/login.php',
+        'login_check': 'https://theshack.us.to/inbox.php',
+        'detail': 'https://theshack.us.to/torrent/%s',
+        'search': 'https://theshack.us.to/torrents.php?action=advanced&searchstr=%s&scene=%s&filter_cat[%d]=1',
+        'download': 'https://theshack.us.to/%s',
     }
 
     http_time_between_calls = 1  # Seconds


### PR DESCRIPTION
The torrenshack.eu domain is no longer available. Read more about it here:
https://www.reddit.com/r/trackers/comments/2vgdxq/tsh_new_adress_theshackusto/

I've only tested 'test', 'login', and 'login_check' urls, and they work.