### PR TITLE
Added 'lowest' and 'low' priorities for pushover notification

### DIFF
--- a/couchpotato/core/notifications/pushover.py
+++ b/couchpotato/core/notifications/pushover.py
@@ -79,7 +79,7 @@ config = [{
                     'name': 'priority',
                     'default': 0,
                     'type': 'dropdown',
-                    'values': [('Normal', 0), ('High', 1)],
+                    'values': [('Lowest', -2), ('Low', -1), ('Normal', 0), ('High', 1)],
                 },
                 {
                     'name': 'on_snatch',


### PR DESCRIPTION
Added 'lowest' and 'low' priorities for notifications as documented here: https://pushover.net/api#priority

Tested locally and worked OK. Low gives no sound and lowest no notification.