### PR TITLE
Fixed the Blu-ray.com backlog by sending the cookie details required to ...

### DIFF
--- a/couchpotato/core/media/movie/providers/automation/bluray.py
+++ b/couchpotato/core/media/movie/providers/automation/bluray.py
@@ -27,12 +27,13 @@ class Bluray(Automation, RSS):
 
         if self.conf('backlog'):
 
+            cookie = {'Cookie': 'listlayout_7=full'}
             page = 0
             while True:
                 page += 1
 
                 url = self.backlog_url % page
-                data = self.getHTMLData(url)
+                data = self.getHTMLData(url, headers = cookie)
                 soup = BeautifulSoup(data)
 
                 try:


### PR DESCRIPTION
...get the listing format the scraper is targetting.