### PR TITLE
Update dashboard.py to handle RecordNotFound errors

### DIFF
--- a/couchpotato/core/plugins/dashboard.py
+++ b/couchpotato/core/plugins/dashboard.py
@@ -1,6 +1,6 @@
 import random as rndm
 import time
-from CodernityDB.database import RecordDeleted
+from CodernityDB.database import RecordDeleted, RecordNotFound
 
 from couchpotato import get_db
 from couchpotato.api import addApiView
@@ -63,6 +63,10 @@ class Dashboard(Plugin):
                     media = db.get('id', media_id)
                 except RecordDeleted:
                     log.debug('Record already deleted: %s', media_id)
+                    continue
+                
+                except RecordNotFound:
+                    log.debug('Record not found: %s', media_id)
                     continue
 
                 pp = profile_pre.get(media.get('profile_id'))


### PR DESCRIPTION
I have been running CP for some time and the DB is not as clean as it should be (upgrades, etc) and I get the following error:

```
04-22 08:09:21 ERROR [31m[          couchpotato.api] Failed doing api request "dashboard.soon": Traceback (most recent call last):
  File "/volume1/.@plugins/AppCentral/couchpotato/CouchPotato/couchpotato/api.py", line 36, in run_handler
    res = api[route](**kwargs)
  File "/volume1/.@plugins/AppCentral/couchpotato/CouchPotato/couchpotato/core/plugins/dashboard.py", line 63, in getSoonView
    media = db.get('id', media_id)
  File "/volume1/.@plugins/AppCentral/couchpotato/CouchPotato/libs/CodernityDB/database_super_thread_safe.py", line 43, in _inner
    res = f(*args, **kwargs)
  File "/volume1/.@plugins/AppCentral/couchpotato/CouchPotato/libs/CodernityDB/database.py", line 942, in get
    raise RecordNotFound(ex)
RecordNotFound: Location '4505fcc515c7439c8b34e638eb21059e' not found
[0m
```
Propose change to handle this exception and continue processing dashboard as normal.
```
04-22 08:25:48 DEBUG [36m[to.core.plugins.dashboard] Record not found: 4505fcc515c7439c8b34e638eb21059e[0m
04-22 08:25:49 DEBUG [36m[to.core.media._base.media] Record not found, skipping: 4505fcc515c7439c8b34e638eb21059e[0m
04-22 08:25:50 DEBUG [36m[to.core.plugins.dashboard] Record not found: 4505fcc515c7439c8b34e638eb21059e[0m
```