### PR TITLE
Fixed trakt integration

### DIFF
--- a/couchpotato/core/media/movie/providers/automation/trakt/main.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/main.py
@@ -24,7 +24,9 @@ class TraktBase(Provider):
             'trakt-api-key': self.client_id,
         }
 
-        post_data = json.dumps(post_data)
+        if post_data:
+            post_data = json.dumps(post_data)
+
         data = self.getJsonData(self.api_url + method_url, data = post_data or {}, headers = headers)
         return data if data else []
 


### PR DESCRIPTION
All operations were sent using the POST method due to json encoding of empty post_data, which caused data retrieval operations to fail (they must be sent using GET).