### PR TITLE
Do not overwrite $HOME variable if present

### DIFF
--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -41,7 +41,8 @@ def symlink(src, dst):
 def getUserDir():
     try:
         import pwd
-        os.environ['HOME'] = sp(pwd.getpwuid(os.geteuid()).pw_dir)
+        if not os.environ['HOME']:
+            os.environ['HOME'] = sp(pwd.getpwuid(os.geteuid()).pw_dir)
     except:
         pass
 


### PR DESCRIPTION
The $HOME environment variable can be changed to accomodate special deployment scenarios, such as limited system accounts with read-only home directories.