### PR TITLE
Update ilovetorrents.py

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/ilovetorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/ilovetorrents.py
@@ -23,7 +23,7 @@ class Base(TorrentProvider):
     }
 
     cat_ids = [
-        (['41'], ['720p', '1080p', 'brrip']),
+        (['80'], ['720p', '1080p', 'brrip']),
         (['19'], ['cam', 'ts', 'dvdrip', 'tc', 'r5', 'scr']),
         (['20'], ['dvdr'])
     ]

--- a/couchpotato/core/media/_base/providers/torrent/ilovetorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/ilovetorrents.py
@@ -88,7 +88,7 @@ class Base(TorrentProvider):
                             id = re.search('id=(?P<id>\d+)&', link).group('id')
                             url = self.urls['download'] % download
 
-                            fileSize = self.parseSize(result.select('td.rowhead')[5].text)
+                            fileSize = self.parseSize(result.select('td.rowhead')[8].text)
                             results.append({
                                 'id': id,
                                 'name': toUnicode(prelink.find('b').text),


### PR DESCRIPTION
Replace category 41 by 80 for 720p, 1080p, brrip. Movies in categroy 81 are better quality than 41 (BluRay vs x264)

Replace fileSize = self.parseSize(result.select('td.rowhead')[5].text) (line 91) by 
fileSize = self.parseSize(result.select('td.rowhead')[8].text) (line 91) which fix filesize fetching issue with ILT