### PR TITLE
Update KickAssTorrents URL

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
+++ b/couchpotato/core/media/_base/providers/torrent/kickasstorrents.py
@@ -30,8 +30,7 @@ class Base(TorrentMagnetProvider):
     cat_backup_id = None
 
     proxy_list = [
-        'https://kickass.to',
-        'http://kickass.pw',
+        'https://kat.cr',
         'http://katproxy.ws',
         'http://kickass.bitproxy.eu',
         'http://katph.eu',


### PR DESCRIPTION
Updated KickAssTorrents URL, to reflect new site domain. Removed dead proxy.