### PR TITLE
Change rcorder of startup script

### DIFF
--- a/init/freebsd
+++ b/init/freebsd
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # PROVIDE: couchpotato
-# REQUIRE: DAEMON
+# REQUIRE: LOGIN
 # KEYWORD: shutdown
 
 # Add the following lines to /etc/rc.conf to enable couchpotato:


### PR DESCRIPTION
CouchPotato doesn't need to run before LOGIN and this is mandatory for non-root user anyway, see #4 under 6.26.1. Pre-Commit Checklist at https://www.freebsd.org/doc/en/books/porters-handbook/rc-scripts.html

Tested on FreeBSD 10.1-RELEASE amd64 as root, non-root with appropriate permissions, service start/status/stop, shutdown, reboot.