### PR TITLE
Fix renamer on systems, which use UTF-8 as default encoding

### DIFF
--- a/couchpotato/core/helpers/encoding.py
+++ b/couchpotato/core/helpers/encoding.py
@@ -36,16 +36,20 @@ def toUnicode(original, *args):
                 return six.text_type(original, *args)
             except:
                 try:
-                    detected = detect(original)
-                    try:
-                        if detected.get('confidence') > 0.8:
-                            return original.decode(detected.get('encoding'))
-                    except:
-                        pass
-
-                    return ek(original, *args)
+                    from couchpotato.environment import Env
+                    return original.decode(Env.get("encoding"))
                 except:
-                    raise
+                    try:
+                        detected = detect(original)
+                        try:
+                            if detected.get('confidence') > 0.8:
+                                return original.decode(detected.get('encoding'))
+                        except:
+                            pass
+
+                        return ek(original, *args)
+                    except:
+                        raise
     except:
         log.error('Unable to decode value "%s..." : %s ', (repr(original)[:20], traceback.format_exc()))
         return 'ERROR DECODING STRING'

--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -25,7 +25,8 @@ def fnEscape(pattern):
 def link(src, dst):
     if os.name == 'nt':
         import ctypes
-        if ctypes.windll.kernel32.CreateHardLinkW(six.text_type(dst), six.text_type(src), 0) == 0: raise ctypes.WinError()
+        from couchpotato.core.helpers.encoding import toUnicode
+        if ctypes.windll.kernel32.CreateHardLinkW(toUnicode(dst), toUnicode(src), 0) == 0: raise ctypes.WinError()
     else:
         os.link(src, dst)
 
@@ -33,7 +34,8 @@ def link(src, dst):
 def symlink(src, dst):
     if os.name == 'nt':
         import ctypes
-        if ctypes.windll.kernel32.CreateSymbolicLinkW(six.text_type(dst), six.text_type(src), 1 if os.path.isdir(src) else 0) in [0, 1280]: raise ctypes.WinError()
+        from couchpotato.core.helpers.encoding import toUnicode
+        if ctypes.windll.kernel32.CreateSymbolicLinkW(toUnicode(dst), toUnicode(src), 1 if os.path.isdir(src) else 0) in [0, 1280]: raise ctypes.WinError()
     else:
         os.symlink(src, dst)
 

--- a/couchpotato/core/media/movie/providers/metadata/base.py
+++ b/couchpotato/core/media/movie/providers/metadata/base.py
@@ -3,7 +3,7 @@ import shutil
 import traceback
 
 from couchpotato.core.event import addEvent, fireEvent
-from couchpotato.core.helpers.encoding import sp
+from couchpotato.core.helpers.encoding import sp, toUnicode
 from couchpotato.core.helpers.variable import getIdentifier, underscoreToCamel
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media._base.providers.metadata.base import MetaDataBase
@@ -32,9 +32,9 @@ class MovieMetaData(MetaDataBase):
         except:
             log.error('Failed to update movie, before creating metadata: %s', traceback.format_exc())
 
-        root_name = self.getRootName(group)
-        meta_name = os.path.basename(root_name)
-        root = os.path.dirname(root_name)
+        root_name = toUnicode(self.getRootName(group))
+        meta_name = toUnicode(os.path.basename(root_name))
+        root = toUnicode(os.path.dirname(root_name))
 
         movie_info = group['media'].get('info')
 

--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -650,7 +650,7 @@ class Renamer(Plugin):
                     group_folder = media_folder
                 else:
                     # Delete the first empty subfolder in the tree relative to the 'from' folder
-                    group_folder = sp(os.path.join(base_folder, os.path.relpath(group['parentdir'], base_folder).split(os.path.sep)[0]))
+                    group_folder = sp(os.path.join(base_folder, toUnicode(os.path.relpath(group['parentdir'], base_folder)).split(os.path.sep)[0]))
 
                 try:
                     if self.conf('cleanup') or self.conf('move_leftover'):

--- a/couchpotato/core/plugins/scanner.py
+++ b/couchpotato/core/plugins/scanner.py
@@ -569,7 +569,7 @@ class Scanner(Plugin):
             scan_result = []
             for p in paths:
                 if not group['is_dvd']:
-                    video = Video.from_path(sp(p))
+                    video = Video.from_path(toUnicode(sp(p)))
                     video_result = [(video, video.scan())]
                     scan_result.extend(video_result)
 


### PR DESCRIPTION
This fixes #4449.
This is not the prettiest fix, but it works. I would advice, to rework the internals towards using unicode wherever it's possible and just encode to sys.getfilesystemencoding() when it's really necessary. I can't think of a modern system, that doesn't understand UTF-8 anyway...