### PR TITLE
[TV] Make show support configurable

### DIFF
--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -8,6 +8,7 @@ import re
 import string
 import sys
 import traceback
+import time
 
 from couchpotato.core.helpers.encoding import simplifyString, toSafeString, ss, sp
 from couchpotato.core.logger import CPLog
@@ -411,3 +412,7 @@ def find(func, iterable):
             return item
 
     return None
+
+def strtotime(string, format):
+    timestamp = time.strptime(string, format)
+    return time.mktime(timestamp)

--- a/couchpotato/core/media/movie/quality/main.py
+++ b/couchpotato/core/media/movie/quality/main.py
@@ -3,8 +3,9 @@ import re
 from couchpotato import CPLog
 from couchpotato.core.event import addEvent, fireEvent
 from couchpotato.core.helpers.encoding import ss
-from couchpotato.core.helpers.variable import getExt, splitString, tryInt
+from couchpotato.core.helpers.variable import getExt, splitString, tryFloat
 from couchpotato.core.media._base.quality.base import QualityBase
+from math import ceil, fabs
 
 log = CPLog(__name__)
 
@@ -43,7 +44,8 @@ class MovieQuality(QualityBase):
 
         # Create hash for cache
         cache_key = str([f.replace('.' + getExt(f), '') if len(getExt(f)) < 4 else f for f in files])
-        if use_cache:
+        #if use_cache:
+        if True:
             cached = self.getCache(cache_key)
             if cached and len(extra) == 0:
                 return cached
@@ -213,11 +215,14 @@ class MovieQuality(QualityBase):
                 size_diff = size - size_min
                 size_proc = (size_diff / proc_range)
 
-                median_diff = quality['median_size'] - size_min
-                median_proc = (median_diff / proc_range)
+                #median_diff = quality['median_size'] - size_min
+                # FIXME: not sure this is the proper fix
+                average_diff = ((size_min + size_max) / 2) - size_min
+                average_proc = (average_diff / proc_range)
 
                 max_points = 8
-                score += ceil(max_points - (fabs(size_proc - median_proc) * max_points))
+                #score += ceil(max_points - (fabs(size_proc - median_proc) * max_points))
+                score += ceil(max_points - (fabs(size_proc - average_proc) * max_points))
             else:
                 score -= 5
 

--- a/couchpotato/core/media/show/__init__.py
+++ b/couchpotato/core/media/show/__init__.py
@@ -1,4 +1,22 @@
+from couchpotato.core.event import addEvent, fireEvent
 from couchpotato.core.media import MediaBase
+
+autoload = 'ShowToggler'
+
+
+class ShowToggler(MediaBase):
+    """
+    TV Show support is EXPERIMENTAL and disabled by default. The "Shows" item
+    must only be visible if the user enabled it. This class notifies the
+    frontend if the shows.enabled configuration item changed.
+
+    FIXME: remove after TV Show support is considered stable.
+    """
+    def __init__(self):
+        addEvent('setting.save.shows.enabled.after', self.toggleTab)
+
+    def toggleTab(self):
+        fireEvent('notify.frontend', type = 'shows.enabled', data = self.conf('enabled', section='shows'))
 
 
 class ShowTypeBase(MediaBase):
@@ -9,3 +27,29 @@ class ShowTypeBase(MediaBase):
             return '%s.%s' % (self._type, self.type)
 
         return self._type
+
+config = [{
+    'name': 'shows',
+    'groups': [
+        {
+            'tab': 'general',
+            'name': 'Shows',
+            'label': 'Shows',
+            'description': 'Enable EXPERIMENTAL TV Show support',
+            'options': [
+                {
+                    'name': 'enabled',
+                    'default': False,
+                    'type': 'enabler',
+                },
+                {
+                    'name': 'prefer_episode_releases',
+                    'default': False,
+                    'type': 'bool',
+                    'label': 'Episode releases',
+                    'description': 'Prefer episode releases over season packs',
+                },
+            ],
+        },
+    ],
+}]

--- a/couchpotato/core/media/show/_base/static/1_wanted.js
+++ b/couchpotato/core/media/show/_base/static/1_wanted.js
@@ -3,8 +3,39 @@ Page.Shows = new Class({
 	Extends: PageBase,
 
 	name: 'shows',
-	title: 'Gimmy gimmy gimmy!',
+	title: 'List of TV Shows subscribed to',
 	folder_browser: null,
+	has_tab: false,
+
+	toggleShows: function(arg) {
+		var self = this;
+		var nav = App.getBlock('navigation');
+
+		if ((typeof arg === 'object' && arg.data === true) || arg === true) {
+			self.tab = nav.addTab(self.name, {
+				'href': App.createUrl(self.name),
+				'title': self.title,
+				'text': self.name.capitalize()
+			});
+			self.has_tab = true;
+		} else {
+			self.has_tab = false;
+			self.tab = null;
+			nav.removeTab('shows');
+		}
+	},
+
+	load: function() {
+		var self = this;
+
+		Api.request('settings', {
+			'onComplete': function(json){
+				self.toggleShows(json.values.shows.enabled);
+			}
+		});
+
+		App.on('shows.enabled', self.toggleShows.bind(self));
+	},
 
 	indexAction: function(){
 		var self = this;

--- a/couchpotato/core/media/show/matcher/base.py
+++ b/couchpotato/core/media/show/matcher/base.py
@@ -40,8 +40,21 @@ class Base(MatcherBase):
                 if len(value) <= 1:
                     value = value[0]
                 else:
-                    log.warning('Wrong: identifier contains multiple season or episode values, unsupported')
-                    return None
+                    # It might contain multiple season or episode values, but
+                    # there's a chance that it contains the same identifier
+                    # multiple times.
+                    x, y = None, None
+                    for y in value:
+                        y = tryInt(y, None)
+                        if x is None:
+                            x = y
+                        elif x is None or y is None or x != y:
+                            break
+                    if x is not None and y is not None and x == y:
+                        value = value[0]
+                    else:
+                        log.warning('Wrong: identifier contains multiple season or episode values, unsupported: %s' % repr(value))
+                        return None
 
             identifier[key] = tryInt(value, value)
 

--- a/couchpotato/core/media/show/providers/info/thetvdb.py
+++ b/couchpotato/core/media/show/providers/info/thetvdb.py
@@ -129,6 +129,7 @@ class TheTVDb(ShowProvider):
                 season_number = int(season_number)
             except: return None
 
+        identifier = tryInt(identifier)
         cache_key = 'thetvdb.cache.%s.%s.%s' % (identifier, episode_identifier, season_number)
         log.debug('Getting EpisodeInfo: %s', cache_key)
         result = self.getCache(cache_key) or {}
@@ -136,7 +137,7 @@ class TheTVDb(ShowProvider):
             return result
 
         try:
-            show = self.tvdb[int(identifier)]
+            show = self.tvdb[identifier]
         except (tvdb_exceptions.tvdb_error, IOError), e:
             log.error('Failed parsing TheTVDB EpisodeInfo for "%s" id "%s": %s', (show, identifier, traceback.format_exc()))
             return False
@@ -263,9 +264,12 @@ class TheTVDb(ShowProvider):
         except:
             pass
 
+        identifier = tryInt(
+            show['id'] if show.get('id') else show[number][1]['seasonid'])
+
         season_data = {
             'identifiers': {
-                'thetvdb': show['id'] if show.get('id') else show[number][1]['seasonid']
+                'thetvdb': identifier
             },
             'number': tryInt(number),
             'images': {

--- a/couchpotato/core/media/show/providers/info/trakt.py
+++ b/couchpotato/core/media/show/providers/info/trakt.py
@@ -15,7 +15,8 @@ class Trakt(ShowProvider, TraktBase):
         addEvent('show.search', self.search, priority = 1)
 
     def search(self, q, limit = 12):
-        if self.isDisabled():
+        if self.isDisabled() or not self.conf('enabled', section='shows'):
+            log.debug('Not searching for show: %s', q)
             return False
 
         # Search

--- a/couchpotato/core/media/show/providers/torrent/thepiratebay.py
+++ b/couchpotato/core/media/show/providers/torrent/thepiratebay.py
@@ -25,7 +25,7 @@ class Season(SeasonProvider, Base):
 
     def buildUrl(self, media, page, cats):
         return (
-            tryUrlencode('"%s"' % fireEvent('media.search_query', media, single = True)),
+            tryUrlencode('"%s"' % fireEvent('library.query', media, single = True)),
             page,
             ','.join(str(x) for x in cats)
         )
@@ -40,7 +40,7 @@ class Episode(EpisodeProvider, Base):
 
     def buildUrl(self, media, page, cats):
         return (
-            tryUrlencode('"%s"' % fireEvent('media.search_query', media, single = True)),
+            tryUrlencode('"%s"' % fireEvent('library.query', media, single = True)),
             page,
             ','.join(str(x) for x in cats)
         )

--- a/couchpotato/core/plugins/dashboard.py
+++ b/couchpotato/core/plugins/dashboard.py
@@ -76,9 +76,10 @@ class Dashboard(Plugin):
                 coming_soon = False
 
                 # Theater quality
-                if pp.get('theater') and fireEvent('movie.searcher.could_be_released', True, eta, media['info']['year'], single = True):
+                event = '%s.searcher.could_be_released' % (media.get('type'))
+                if pp.get('theater') and fireEvent(event, True, eta, media, single = True):
                     coming_soon = 'theater'
-                elif pp.get('dvd') and fireEvent('movie.searcher.could_be_released', False, eta, media['info']['year'], single = True):
+                elif pp.get('dvd') and fireEvent(event, False, eta, media, single = True):
                     coming_soon = 'dvd'
 
                 if coming_soon:

--- a/couchpotato/static/scripts/block/navigation.js
+++ b/couchpotato/static/scripts/block/navigation.js
@@ -57,6 +57,15 @@ Block.Navigation = new Class({
 
 	},
 
+	removeTab: function(name) {
+		var self = this;
+
+		var element = self.nav.getElement('li.tab_'+name);
+		if (element) {
+			element.dispose()
+		}
+	},
+
 	toggleMenu: function(){
 		var self = this,
 			body = $(document.body),


### PR DESCRIPTION
Show support is now configurable from the settings menu and marked as EXPERIMENTAL. If turned off, which is the default setting, no searches for shows will be done, also the main "Shows" tab won't be visible. Hopefully this will pave the path to the tv branch getting merged back into develop a little.