### PR TITLE
Add support for custom bookmarklet URL.

### DIFF
--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -311,6 +311,10 @@ config = [{
                     'description': 'Leave blank for no password.',
                 },
                 {
+                    'name': 'bookmarklet_host',
+                    'description': 'Override default bookmarklet host. This can be useful in a reverse proxy environment. For example: "http://username:password@customHost:1020". Requires restart to take effect.',
+                },
+                {
                     'name': 'debug',
                     'default': 0,
                     'type': 'bool',

--- a/couchpotato/core/plugins/userscript/main.py
+++ b/couchpotato/core/plugins/userscript/main.py
@@ -56,12 +56,15 @@ class Userscript(Plugin):
 
             def get(self, random, route):
 
+                bookmarklet_host = Env.setting('bookmarklet_host')
+                loc = bookmarklet_host if bookmarklet_host else "{0}://{1}".format(self.request.protocol, self.request.headers.get('X-Forwarded-Host') or self.request.headers.get('host'))
+
                 params = {
                     'includes': fireEvent('userscript.get_includes', merge = True),
                     'excludes': fireEvent('userscript.get_excludes', merge = True),
                     'version': klass.getVersion(),
                     'api': '%suserscript/' % Env.get('api_base'),
-                    'host': '%s://%s' % (self.request.protocol, self.request.headers.get('X-Forwarded-Host') or self.request.headers.get('host')),
+                    'host': loc,
                 }
 
                 script = klass.renderTemplate(__file__, 'template.js_tmpl', **params)


### PR DESCRIPTION
This is very useful in reverse proxy environments, especially if you have BasicAuth-protected proxies.

For instance, my URL is:
https://myusername:mypassword@customHost:443

Behind that reverse proxy I make requests to a non-SSL enabled CouchPotato server (the proxy takes care of certificates), so as far as CouchPotato knows, it should just use HTTP and not HTTPS.
Also, CouchPotato doesn't know about the username/password on my proxy-server.

Without this, I can't get the bookmarklet to work.