### PR TITLE
Change dereferer default to nullrefer.com

### DIFF
--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -295,7 +295,7 @@ config = [{
                 },
                 {
                     'name': 'dereferer',
-                    'default': 'http://www.dereferer.org/?',
+                    'default': 'http://www.nullrefer.com/?',
                     'description': 'Derefer links to external sites, keep empty for no dereferer. Example: http://www.dereferer.org/? or http://www.nullrefer.com/?.',
                 },
                 {


### PR DESCRIPTION
Current default is deferer.org which is down more times than up. Other users have complained before (see: #5152). Changing this to www.nullrefer.com which is provided as the alternate