### PR TITLE
Add install step to install pyOpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Linux:
 * (Fedora / CentOS) Install [GIT](http://git-scm.com/) with `yum install git`
 * Install [LXML](http://lxml.de/installation.html) for better/faster website scraping 
 * 'cd' to the folder of your choosing.
+* Install [PyOpenSSL](https://pypi.python.org/pypi/pyOpenSSL) with `pip install --upgrade pyopenssl`
 * Run `git clone https://github.com/RuudBurger/CouchPotatoServer.git`
 * Then do `python CouchPotatoServer/CouchPotato.py` to start
 * (Ubuntu / Debian) To run on boot copy the init script `sudo cp CouchPotatoServer/init/ubuntu /etc/init.d/couchpotato`


### PR DESCRIPTION
See https://github.com/RuudBurger/CouchPotatoServer/issues/5391

It's important we tell people to do this or else CouchPotato won't be able to make external SSL/TLS connections. This causes most functionality to stop functioning including collecting metadata, searching providers, and notifications.
