### PR TITLE
Permission check for ssl cert and key

### DIFF
--- a/libs/tornado/tcpserver.py
+++ b/libs/tornado/tcpserver.py
@@ -106,6 +106,18 @@ class TCPServer(object):
             if 'certfile' not in self.ssl_options:
                 raise KeyError('missing key "certfile" in ssl_options')
 
+            # Run os.stat against cert and keyfile to test permissions,
+            # if not, just raise the exception
+            try:
+                os.stat(self.ssl_options['certfile'])
+            except:
+                raise
+
+            try:
+                os.stat(self.ssl_options['keyfile'])
+            except:
+                raise
+
             if not os.path.exists(self.ssl_options['certfile']):
                 raise ValueError('certfile "%s" does not exist' %
                                  self.ssl_options['certfile'])


### PR DESCRIPTION
If the user starting the CP service doesn't have enough permissions, the current error will be  "does not exist".
With this change it will check permissions first with os.stat, and raise the exception:
OSError: [Errno 13] Permission denied: '</path/to/file'

Hopefully this will help users debugging why they can't get it to work with https.

Also, I don't know if there is a better way to do this check (probably is.. :) )