### PR TITLE
Update nzbget url

### DIFF
--- a/couchpotato/core/downloaders/nzbget.py
+++ b/couchpotato/core/downloaders/nzbget.py
@@ -253,7 +253,7 @@ config = [{
             'list': 'download_providers',
             'name': 'nzbget',
             'label': 'NZBGet',
-            'description': 'Use <a href="http://nzbget.sourceforge.net/Main_Page" target="_blank">NZBGet</a> to download NZBs.',
+            'description': 'Use <a href="http://nzbget.net" target="_blank">NZBGet</a> to download NZBs.',
             'wizard': True,
             'options': [
                 {


### PR DESCRIPTION
http://nzbget.sourceforge.net/Main_Page leads to http://nzbget.net/Main_Page which throws 404