### PR TITLE
Fix server abuse because of bad credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ You can now change css and javascript and it wil reload the page when needed.
 
 By default it will combine files used in the core folder. If you're adding a new .scss or .js file, you might need to add it and then restart the grunt process for it to combine it properly.
 
-Don't forget to enable development inside the CP settings. This disables some functions and also makes sure javascript rrors are pushed to console instead of the log.
+Don't forget to enable development inside the CP settings. This disables some functions and also makes sure javascript errors are pushed to console instead of the log.

--- a/couchpotato/core/media/_base/providers/torrent/passthepopcorn.py
+++ b/couchpotato/core/media/_base/providers/torrent/passthepopcorn.py
@@ -193,7 +193,8 @@ config = [{
             'name': 'PassThePopcorn',
             'description': '<a href="https://passthepopcorn.me">PassThePopcorn.me</a>',
             'wizard': True,
-            'icon': 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAARklEQVQoz2NgIAP8BwMiGWRpIN1JNWn/t6T9f532+W8GkNt7vzz9UkfarZVpb68BuWlbnqW1nU7L2DMx7eCoBlpqGOppCQB83zIgIg+wWQAAAABJRU5ErkJggg==',
+            'icon': 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAARklEQVQoz2NgIAP8BwMiGWRpIN1JNWn/t6T9f5'
+                    '32+W8GkNt7vzz9UkfarZVpb68BuWlbnqW1nU7L2DMx7eCoBlpqGOppCQB83zIgIg+wWQAAAABJRU5ErkJggg==',
             'options': [
                 {
                     'name': 'enabled',
@@ -255,14 +256,14 @@ config = [{
                     'name': 'seed_ratio',
                     'label': 'Seed ratio',
                     'type': 'float',
-                    'default': 1,
+                    'default': 2,
                     'description': 'Will not be (re)moved until this seed ratio is met.',
                 },
                 {
                     'name': 'seed_time',
                     'label': 'Seed time',
                     'type': 'int',
-                    'default': 40,
+                    'default': 96,
                     'description': 'Will not be (re)moved until this seed time (in hours) is met.',
                 },
                 {


### PR DESCRIPTION
Fixes #2232

No HTTP 4xx is likely to find success by retrying the same request. 3 failures will disable the provider and log an appropriate message.

Note that the changes in ptp.py can only deal with failures resulting in HTTP 200 and "Result"!="ok", the base.py changes are for HTTP 4xx .

Tested for PTP, and should never be a problem for anything else since a 4xx response cannot continue anyway.