### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Linux:
 * Install [PyOpenSSL](https://pypi.python.org/pypi/pyOpenSSL) with `pip install --upgrade pyopenssl`
 * Run `git clone https://github.com/RuudBurger/CouchPotatoServer.git`
 * Then do `python CouchPotatoServer/CouchPotato.py` to start
-* (Ubuntu / Debian) To run on boot copy the init script `sudo cp CouchPotatoServer/init/ubuntu /etc/init.d/couchpotato`
-* (Ubuntu / Debian) Copy the default paths file `sudo cp CouchPotatoServer/init/ubuntu.default /etc/default/couchpotato`
-* (Ubuntu / Debian) Change the paths inside the default file `sudo nano /etc/default/couchpotato`
-* (Ubuntu / Debian) Make it executable `sudo chmod +x /etc/init.d/couchpotato`
-* (Ubuntu / Debian) Add it to defaults `sudo update-rc.d couchpotato defaults`
-* (systemd) To run on boot copy the systemd config `sudo cp CouchPotatoServer/init/couchpotato.fedora.service /etc/systemd/system/couchpotato.service`
-* (systemd) Update the systemd config file with your user and path to CouchPotato.py 
-* (systemd) Enable it at boot with `sudo systemctl enable couchpotato`
+* (Ubuntu / Debian with upstart) To run on boot copy the init script `sudo cp CouchPotatoServer/init/ubuntu /etc/init.d/couchpotato`
+* (Ubuntu / Debian with upstart) Copy the default paths file `sudo cp CouchPotatoServer/init/ubuntu.default /etc/default/couchpotato`
+* (Ubuntu / Debian with upstart) Change the paths inside the default file `sudo nano /etc/default/couchpotato`
+* (Ubuntu / Debian with upstart) Make it executable `sudo chmod +x /etc/init.d/couchpotato`
+* (Ubuntu / Debian with upstart) Add it to defaults `sudo update-rc.d couchpotato defaults`
+* (Linux with systemd) To run on boot copy the systemd config `sudo cp CouchPotatoServer/init/couchpotato.service /etc/systemd/system/couchpotato.service`
+* (Linux with systemd) Update the systemd config file with your user and path to CouchPotato.py
+* (Linux with systemd) Enable it at boot with `sudo systemctl enable couchpotato`
 * Open your browser and go to `http://localhost:5050/`
 
 Docker:

--- a/init/couchpotato.fedora.service
+++ b/init/couchpotato.fedora.service
@@ -1,13 +1,1 @@
-[Unit]
-Description=CouchPotato application instance
-After=network.target
-
-[Service]
-ExecStart=/var/lib/CouchPotatoServer/CouchPotato.py --daemon 
-GuessMainPID=no
-Type=forking
-User=couchpotato
-Group=couchpotato
-
-[Install]
-WantedBy=multi-user.target
+couchpotato.service

--- a/init/couchpotato.service
+++ b/init/couchpotato.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=CouchPotato application instance
+After=network.target
+
+[Service]
+ExecStart=/var/lib/CouchPotatoServer/CouchPotato.py --daemon 
+GuessMainPID=no
+Type=forking
+User=couchpotato
+Group=couchpotato
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Since ubuntu 15.04 also uses systemd as default, I've updated the README and renamed the systemd init script to make it more generic. I haven't actually tested the systemd init script on ubuntu myself, but I suspect it to work.

Created a symlink with the old name (i.e ```init/couchpotato.fedora.service -> init/couchpotato.service```) so we won't confuse anyone used to use that name