### PR TITLE
Remove deprecated viewport argument and fix Safari flexbox bug

### DIFF
--- a/couchpotato/static/style/combined.min.css
+++ b/couchpotato/static/style/combined.min.css
@@ -854,7 +854,7 @@ input[type=text],textarea{-webkit-appearance:none}
 .dark .page.settings .tabs li a{color:rgba(255,255,255,.5)}
 .page.settings .tabs li.active a{color:#000}
 .dark .page.settings .tabs li.active a{color:#FFF}
-.page.settings form.containers{margin:0 20px 0 0;-webkit-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto}
+.page.settings form.containers{margin:0 20px 0 0;-webkit-flex:1;-ms-flex:1;flex:1}
 @media (max-width:480px){.page.settings form.containers{margin:0 10px 0 0}
 }
 .page.settings fieldset h2 .group_label,.page.settings fieldset h2 .icon{margin-right:10px}

--- a/couchpotato/static/style/settings.scss
+++ b/couchpotato/static/style/settings.scss
@@ -71,7 +71,7 @@
 
 	form.containers {
 		margin: 0 $padding 0 0;
-		flex: 1 1 auto;
+		flex: 1;
 
 		@include media-phablet {
 			margin: 0 $padding/2 0 0;

--- a/couchpotato/templates/index.html
+++ b/couchpotato/templates/index.html
@@ -3,7 +3,7 @@
 <html class="{{ 'dark' if Env.setting('dark_theme') else '' }}">
 	<head>
 		<title>CouchPotato</title>
-		<meta name="viewport" content="minimal-ui, width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="mobile-web-app-capable" content="yes" />
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
"Viewport argument key "minimal-ui" not recognized and ignored."

No testing needed, as this is iPhone specific and deprecated.