### PR TITLE
don't create .ignore on files we're going to cleanup anyway

### DIFF
--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -726,7 +726,7 @@ Remove it if you want it to be renamed (again, or at least let it try again)
         for filename in tag_files:
 
             # Don't tag .ignore files or when renamer is set to cleanup
-            if os.path.splitext(filename)[1] == '.ignore' or not self.conf('cleanup'):
+            if os.path.splitext(filename)[1] == '.ignore' or self.conf('cleanup'):
                 continue
 
             tag_filename = '%s.%s.ignore' % (os.path.splitext(filename)[0], tag)

--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -725,8 +725,8 @@ Remove it if you want it to be renamed (again, or at least let it try again)
 
         for filename in tag_files:
 
-            # Don't tag .ignore files
-            if os.path.splitext(filename)[1] == '.ignore':
+            # Don't tag .ignore files or when renamer is set to cleanup
+            if os.path.splitext(filename)[1] == '.ignore' or not self.conf('cleanup'):
                 continue
 
             tag_filename = '%s.%s.ignore' % (os.path.splitext(filename)[0], tag)


### PR DESCRIPTION
If we're going to remove them anyway, why even create them

This also somewhat fixes problems with torrent clients not beeing able to remove directories where .ignore files are present