### PR TITLE
Remove check if download folder exists for Transmission downloader

### DIFF
--- a/couchpotato/core/downloaders/transmission.py
+++ b/couchpotato/core/downloaders/transmission.py
@@ -67,10 +67,7 @@ class Transmission(DownloaderBase):
         }
 
         if self.conf('directory'):
-            if os.path.isdir(self.conf('directory')):
-                params['download-dir'] = self.conf('directory').rstrip(os.path.sep)
-            else:
-                log.error('Download directory from Transmission settings: %s doesn\'t exist', self.conf('directory'))
+            params['download-dir'] = self.conf('directory').rstrip(os.path.sep)
 
         # Change parameters of torrent
         torrent_params = {}


### PR DESCRIPTION
When running Transmission remotely from CouchPotato, it is not possible to check if the downloads directory exists before sending to Transmission. This PR removes that check so that it is possible to use any directory without having to workaround by creating an empty directory with the same path on the CouchPotato machine.