### PR TITLE
fixes and improvements for ubuntu init.d and settings file

### DIFF
--- a/init/ubuntu
+++ b/init/ubuntu
@@ -1,124 +1,107 @@
-#! /bin/sh
+#!/bin/sh
+#
+# DON'T EDIT THIS FILE DIRECTLY!
+#
+# Instead, create your own configuration by setting any of the 7 variables
+# listed below in /etc/default/couchpotato. For example: adding CP_USER=noob
+# to /etc/default/couchpotato makes the service run under the 'noob' account,
+# overruling the default value of 'couchpotato'.
+#
+# Accepted variables with default values -if any- in parentheses:
+# CP_USER	# username to run couchpotato under (couchpotato)
+# CP_HOME	# directory of CouchPotato.py (/opt/couchpotato)
+# CP_DATA	# directory of couchpotato's db, cache and logs (/var/opt/couchpotato)
+# CP_PIDFILE	# full path of couchpotato.pid (/var/run/couchpotato/couchpotato.pid)
+# PYTHON_BIN	# full path of the python binary (/usr/bin/python)
+# CP_OPTS	# extra cli options for couchpotato, see 'CouchPotato.py --help'
+# SSD_OPTS	# extra options for start-stop-daemon, see 'man start-stop-daemon'
 
 ### BEGIN INIT INFO
 # Provides:          couchpotato
-# Required-Start:    $local_fs $network $remote_fs
-# Required-Stop:     $local_fs $network $remote_fs
-# Should-Start:      $NetworkManager
-# Should-Stop:       $NetworkManager
+# Required-Start:    $network $remote_fs
+# Required-Stop:     $network $remote_fs
+# Should-Start:      $named deluged network-manager nzbget qbittorrent-nox sabnzbdplus transmission-daemon
+# Should-Stop:       $named deluged network-manager nzbget qbittorrent-nox sabnzbdplus transmission-daemon
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: starts instance of CouchPotato
+# Short-Description: CouchPotato PVR for Usenet and torrents
 # Description:       starts instance of CouchPotato using start-stop-daemon
 ### END INIT INFO
 
-# Check for existance of defaults file
-# and utilze if available
-if [ -f /etc/default/couchpotato ]; then
-    . /etc/default/couchpotato
-else
-    echo "/etc/default/couchpotato not found using default settings.";
-fi
+DESC=CouchPotato
+CONFIG=/etc/default/couchpotato
 
+# don't accept config vars from the shell environment
+unset CP_USER CP_HOME CP_DATA CP_PIDFILE PYTHON_BIN CP_OPTS SSD_OPTS
+
+# source lsb init functions
 . /lib/lsb/init-functions
 
-# Script name
-NAME=couchpotato
+# try loading the configuration file
+[ -r "$CONFIG" ] && . "$CONFIG" \
+	|| log_action_msg "$DESC: $CONFIG unreadable, falling back to default settings"
 
-# App name
-DESC=CouchPotato
+# assorted settings and their defaults
+: "${CP_USER:=couchpotato}"
+: "${CP_HOME:=/opt/couchpotato}"
+: "${CP_DATA:=/var/opt/couchpotato}"
+: "${CP_PIDFILE:=/var/run/couchpotato/couchpotato.pid}"
+: "${PYTHON_BIN:=/usr/bin/python}"
 
-## Don't edit this file
-## Edit user configuation in /etc/default/couchpotato to change
-##
-## CP_USER= #$RUN_AS, username to run couchpotato under, the default is couchpotato
-## CP_HOME= #$APP_PATH, the location of couchpotato.py, the default is /opt/couchpotato
-## CP_DATA= #$DATA_DIR, the location of couchpotato.db, cache, logs, the default is /var/opt/couchpotato
-## CP_PIDFILE= #$PID_FILE, the location of couchpotato.pid, the default is /var/run/couchpotato/couchpotato.pid
-## PYTHON_BIN= #$DAEMON, the location of the python binary, the default is /usr/bin/python
-## CP_OPTS= #$EXTRA_DAEMON_OPTS, extra cli option for couchpotato, i.e. " --config_file=/home/couchpotato/couchpotato.ini"
-## SSD_OPTS= #$EXTRA_SSD_OPTS, extra start-stop-daemon option like " --group=users"
-##
-## EXAMPLE if want to run as different user
-## add CP_USER=username to /etc/default/couchpotato
-## otherwise default couchpotato is used
+# basic sanity checks
+([ -x "$PYTHON_BIN" ] && [ -f "$CP_HOME/CouchPotato.py" ]) || {
+	log_failure_msg "$DESC: init script setup failed basic sanity checks, aborting!";
+	# exit zero since this condition may also occur after a user
+	# uninstalled cp while leaving this script in place.
+	exit 0;
+}
 
-# Run CP as username
-RUN_AS=${CP_USER-couchpotato}
+start_cp() {
+	# create directories with sensible ownership and permissions
+	# (but refuse to touch any pre-existing ones)
+	for D in "$(dirname "$CP_PIDFILE")" "$CP_DATA"; do
+		[ ! -d "$D" ] && {
+			install --directory --owner="$CP_USER" --group=root --mode=0700 "$D" || exit 1;
+		}
+	done
 
-# Path to app
-# CP_HOME=path_to_app_CouchPotato.py
-APP_PATH=${CP_HOME-/opt/couchpotato/}
+#	# for backwards compatibility create an empty pidfile so it
+#	# can be in any pre-existing directory, even those unwritable
+#	# for the $CP_USER. PEBCAK?
+#	[ ! -e "$CP_PIDFILE" ] && {
+#		touch "$CP_PIDFILE" && \
+#		chmod 0600 "$CP_PIDFILE" && \
+#		chown "$CP_USER" "$CP_PIDFILE" \
+#		|| exit 1;
+#	}
 
-# Data directory where couchpotato.db, cache and logs are stored
-DATA_DIR=${CP_DATA-/var/opt/couchpotato}
+	log_daemon_msg "Starting $DESC"
+	start-stop-daemon --start --quiet --pidfile "$CP_PIDFILE" --chdir "$CP_HOME" --chuid "$CP_USER" --oknodo --exec "$PYTHON_BIN" $SSD_OPTS -- \
+		CouchPotato.py --daemon --quiet --pid_file="$CP_PIDFILE" --data_dir="$CP_DATA" $CP_OPTS
+	log_end_msg $? || exit $?
+}
 
-# Path to store PID file
-PID_FILE=${CP_PIDFILE-/var/run/couchpotato/couchpotato.pid}
-
-# path to python bin
-DAEMON=${PYTHON_BIN-/usr/bin/python}
-
-# Extra daemon option like: CP_OPTS=" --config=/home/couchpotato/couchpotato.ini"
-EXTRA_DAEMON_OPTS=${CP_OPTS-}
-
-# Extra start-stop-daemon option like START_OPTS=" --group=users"
-EXTRA_SSD_OPTS=${SSD_OPTS-}
-
-
-PID_PATH=`dirname $PID_FILE`
-DAEMON_OPTS=" CouchPotato.py --quiet --daemon --pid_file=${PID_FILE} --data_dir=${DATA_DIR} ${EXTRA_DAEMON_OPTS}"
-
-
-test -x $DAEMON || exit 0
-
-set -e
-
-# Create PID directory if not exist and ensure the CouchPotato user can write to it
-if [ ! -d $PID_PATH ]; then
-    mkdir -p $PID_PATH
-    chown $RUN_AS $PID_PATH
-fi
-
-if [ ! -d $DATA_DIR ]; then
-    mkdir -p $DATA_DIR
-    chown $RUN_AS $DATA_DIR
-fi
-
-if [ -e $PID_FILE ]; then
-    PID=`cat $PID_FILE`
-    if ! kill -0 $PID > /dev/null 2>&1; then
-        echo "Removing stale $PID_FILE"
-        rm $PID_FILE
-    fi
-fi
+stop_cp() {
+	log_daemon_msg "Stopping $DESC"
+	# for security reasons, require the process to be both:
+	# 1) listed in the pidfile and 2) running as $CP_USER
+	start-stop-daemon --stop --quiet --pidfile "$CP_PIDFILE" --user "$CP_USER" --retry 15 --oknodo
+	log_end_msg $? || exit $?
+}
 
 case "$1" in
-  start)
-        touch $PID_FILE
-        chown $RUN_AS $PID_FILE
-        echo "Starting $DESC"
-        start-stop-daemon -d $APP_PATH -c $RUN_AS $EXTRA_SSD_OPTS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
-        ;;
-  stop)
-        echo "Stopping $DESC"
-        start-stop-daemon --stop --pidfile $PID_FILE --retry 15 --oknodo
-        ;;
-
-  restart|force-reload)
-        echo "Restarting $DESC"
-        start-stop-daemon --stop --pidfile $PID_FILE --retry 15 --oknodo
-        start-stop-daemon -d $APP_PATH -c $RUN_AS $EXTRA_SSD_OPTS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
-        ;;
-
-  status)
-       status_of_proc -p $PID_FILE "$DAEMON" "$NAME"
-        ;;
-  *)
-        N=/etc/init.d/$NAME
-        echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
-        exit 1
-        ;;
+	start)
+		start_cp;;
+	stop)
+		stop_cp;;
+	restart|force-reload)
+		stop_cp && start_cp;;
+	status)
+		status_of_proc -p "$CP_PIDFILE" "$PYTHON_BIN" "$DESC"
+		exit $?;;
+	*)
+		echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2
+		exit 3;;
 esac
 
 exit 0

--- a/init/ubuntu.default
+++ b/init/ubuntu.default
@@ -1,5 +1,19 @@
 # COPY THIS FILE TO /etc/default/couchpotato 
-# OPTIONS: CP_HOME, CP_USER, CP_DATA, CP_PIDFILE, PYTHON_BIN, CP_OPTS, SSD_OPTS
+# Accepted variables with default values -if any- in parentheses:
 
+# username to run couchpotato under (couchpotato)
+CP_USER=couchpotato
+# directory of CouchPotato.py (/opt/couchpotato)
 CP_HOME=
-CP_USER=root
+
+# directory of couchpotato's db, cache and logs (/var/opt/couchpotato)
+CP_DATA=
+# full path of couchpotato.pid (/var/run/couchpotato/couchpotato.pid)
+CP_PIDFILE=
+# full path of the python binary (/usr/bin/python)
+PYTHON_BIN=
+
+# extra cli options for couchpotato, see 'CouchPotato.py --help'
+CP_OPTS=
+# extra options for start-stop-daemon, see 'man start-stop-daemon'
+SSD_OPTS=


### PR DESCRIPTION
Many fixes for the init.d script and its settings file, bringing things up to spec with debian policy and attempting to improve the script's security and documentation. Tested on my ubuntu 14.04 install but should work fine with anything similar too.

**Changes**
_Init.d:_
* move documentation and the list of accepted config vars to the top of the script.
* replace the ambiguous term "location" which could previously mean both "directory" and "full path to a file" depending on the variable.
* update INIT INFO Should-{Start,Stop} to include services cp may want to communicate with.
* prevent unintentionally inheriting config vars from the shell environment.
* use the same var names throughout the script.
* improve the sanity check to include a check of the main cp executable.
* move start and stop stanzas into functions to prevent code duplication in the restart action.
* put the code for dealing with missing dirs inside the start stanza (not needed with other actions).
* use install to create dirs with correct permissions/ownership, without relying on the presence of a sane umask.
* use lsb log_*_msg functions for nicely formatted console output.
* action stop: require the process to be running under the configured user account in addition to being listed in the pidfile. Not doing so may allow a malicious CP_USER to manipulate the pid file and trick an admin or automated process supervisor into killing unrelated processes.
* action status: correct the exit status of the script; the previous version would print an accurate message for human consumption but not set the exit status accordingly.
* set correct exit status for the catch-all.

_Settings file:_
* add all accepted vars, with their description and default value.
* don't set the CP_USER to root by default.


**Compatibility**
All config vars and their default values have been left unchanged and the whole script should be fully backward compatible requiring no changes to an existing config kept in /etc/default/couchpotato, with the sole exception of the commented-out code block in the start_cp function dealing with pid files in pre-existing but unwritable dirs.
I consider that condition user error and given the difficulty in checking for writability of a directory in shell for another user than the one running the script (and thus in running that code only in case it's actually needed) I just commented that bit out. If you want to keep the previous behaviour anyway then just uncomment those lines.