### PR TITLE
Add 2160p quality support

### DIFF
--- a/couchpotato/core/plugins/profile/main.py
+++ b/couchpotato/core/plugins/profile/main.py
@@ -206,6 +206,9 @@ class ProfilePlugin(Plugin):
                 'label': '3D HD',
                 'qualities': ['1080p', '720p'],
                 '3d': [True, True]
+            }, {
+                'label': 'UHD 4K',
+                'qualities': ['720p', '1080p', '2160p']
             }]
 
             # Create default quality profile

--- a/couchpotato/core/plugins/quality/main.py
+++ b/couchpotato/core/plugins/quality/main.py
@@ -23,6 +23,7 @@ class QualityPlugin(Plugin):
     }
 
     qualities = [
+		{'identifier': '2160p', 'hd': True, 'allow_3d': True, 'size': (10000, 650000), 'median_size': 20000, 'label': '2160p', 'width': 3840, 'height': 2160, 'alternative': [], 'allow': [], 'ext':['mkv'], 'tags': ['x264', 'h264', '2160']},
         {'identifier': 'bd50', 'hd': True, 'allow_3d': True, 'size': (20000, 60000), 'median_size': 40000, 'label': 'BR-Disk', 'alternative': ['bd25', ('br', 'disk')], 'allow': ['1080p'], 'ext':['iso', 'img'], 'tags': ['bdmv', 'certificate', ('complete', 'bluray'), 'avc', 'mvc']},
         {'identifier': '1080p', 'hd': True, 'allow_3d': True, 'size': (4000, 20000), 'median_size': 10000, 'label': '1080p', 'width': 1920, 'height': 1080, 'alternative': [], 'allow': [], 'ext':['mkv', 'm2ts', 'ts'], 'tags': ['m2ts', 'x264', 'h264', '1080']},
         {'identifier': '720p', 'hd': True, 'allow_3d': True, 'size': (3000, 10000), 'median_size': 5500, 'label': '720p', 'width': 1280, 'height': 720, 'alternative': [], 'allow': [], 'ext':['mkv', 'ts'], 'tags': ['x264', 'h264', '720']},
@@ -65,6 +66,7 @@ class QualityPlugin(Plugin):
         })
 
         addEvent('app.initialize', self.fill, priority = 10)
+        addEvent('app.load', self.fill, priority = 120)
 
         addEvent('app.test', self.doTest)
 
@@ -493,6 +495,8 @@ class QualityPlugin(Plugin):
             'Movie.Name.2014.720p.HDSCR.4PARTS.MP4.AAC.ReleaseGroup': {'size': 2401, 'quality': 'scr'},
             'Movie.Name.2014.720p.BluRay.x264-ReleaseGroup': {'size': 10300, 'quality': '720p'},
             'Movie.Name.2014.720.Bluray.x264.DTS-ReleaseGroup': {'size': 9700, 'quality': '720p'},
+            'Movie Name 2015 2160p SourceSite WEBRip DD5 1 x264-ReleaseGroup': {'size': 21800, 'quality': '2160p'},
+            'Movie Name 2012 2160p WEB-DL FLAC 5 1 x264-ReleaseGroup': {'size': 59650, 'quality': '2160p'}
         }
 
         correct = 0

--- a/couchpotato/core/plugins/scanner.py
+++ b/couchpotato/core/plugins/scanner.py
@@ -74,6 +74,7 @@ class Scanner(Plugin):
     }
 
     resolutions = {
+		'2160p': {'resolution_width': 3840, 'resolution_height': 2160, 'aspect': 1.78},
         '1080p': {'resolution_width': 1920, 'resolution_height': 1080, 'aspect': 1.78},
         '1080i': {'resolution_width': 1920, 'resolution_height': 1080, 'aspect': 1.78},
         '720p': {'resolution_width': 1280, 'resolution_height': 720, 'aspect': 1.78},

--- a/couchpotato/core/plugins/score/scores.py
+++ b/couchpotato/core/plugins/score/scores.py
@@ -19,7 +19,7 @@ name_scores = [
     # Audio
     'dts:4', 'ac3:2',
     # Quality
-    '720p:10', '1080p:10', 'bluray:10', 'dvd:1', 'dvdrip:1', 'brrip:1', 'bdrip:1', 'bd50:1', 'bd25:1',
+    '720p:10', '1080p:10', '2160p:10', 'bluray:10', 'dvd:1', 'dvdrip:1', 'brrip:1', 'bdrip:1', 'bd50:1', 'bd25:1',
     # Language / Subs
     'german:-10', 'french:-10', 'spanish:-10', 'swesub:-20', 'danish:-10', 'dutch:-10',
     # Release groups


### PR DESCRIPTION
Resolves issue #4596 .

I added an app.load event to the QualityPlugin to fill the qualities every time the app loads. This is so that new qualities that are added after someone has run the application once will still show up. I tested this and didn't encounter any issues.