### PR TITLE
Fix renamer ignoring the .ignore file

### DIFF
--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -807,7 +807,7 @@ Remove it if you want it to be renamed (again, or at least let it try again)
             ignore_files.extend(fnmatch.filter([sp(os.path.join(root, filename)) for filename in filenames], '*%s.ignore' % tag))
 
         # Match all found ignore files with the tag_files and return True found
-        for tag_file in tag_files:
+        for tag_file in [tag_files] if isinstance(tag_files,str) else tag_files:
             ignore_file = fnmatch.filter(ignore_files, fnEscape('%s.%s.ignore' % (os.path.splitext(tag_file)[0], tag if tag else '*')))
             if ignore_file:
                 return True
@@ -1228,6 +1228,9 @@ Remove it if you want it to be renamed (again, or at least let it try again)
                                 log.error('Rar modify date enabled, but failed: %s', traceback.format_exc())
                         extr_files.append(extr_file_path)
                 del rar_handle
+                # Tag archive as extracted if no cleanup.  
+                if not cleanup and os.path.isfile(extr_file_path):
+                    self.tagRelease(release_download = {'folder': os.path.dirname(archive['file']), 'files': [archive['file']]}, tag = 'extracted')
             except Exception as e:
                 log.error('Failed to extract %s: %s %s', (archive['file'], e, traceback.format_exc()))
                 continue


### PR DESCRIPTION
This release fixed issue #4443 #4122

Row 1196, sends a string, archive['file'], to hastagRelease()  which causing the loop at row 810 to break (since it iterates over a string)

Row 811:  fnmatch.filter() is case sensitive on linux system (depends on the OS actually).
We are comparing the ignore files to archive files, BUT the the ignore file was created with the name of the extracted file and not the archive files (see row 644).
If there is a difference between the extracted file and archive file the ignore file will be no good and extraction will occur again.. 
Usually scene release archive files are all low-case while the extracted files are not. I suggest to tag the archive file when the renamer is keeping the rar files (no cleanup) in-order to prevent re-extraction of the files over and over again.

Row 1232: I added tagging to archive file only if there is no cleanup. I also add another sanity check if the file was really extracted because if you kill unrar process while it runs it does not generate exception that extracting was stopped. 

**One Question**:
Is the raise of exception at row 821 really needed?
I think it can be removed.. because it will cause both copies to exist which will just consume more space.