### PR TITLE
Awesome-HD change from .net to .me

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/awesomehd.py
+++ b/couchpotato/core/media/_base/providers/torrent/awesomehd.py
@@ -13,10 +13,10 @@ log = CPLog(__name__)
 class Base(TorrentProvider):
 
     urls = {
-        'test': 'https://awesome-hd.net/',
-        'detail': 'https://awesome-hd.net/torrents.php?torrentid=%s',
-        'search': 'https://awesome-hd.net/searchapi.php?action=imdbsearch&passkey=%s&imdb=%s&internal=%s',
-        'download': 'https://awesome-hd.net/torrents.php?action=download&id=%s&authkey=%s&torrent_pass=%s',
+        'test': 'https://awesome-hd.me/',
+        'detail': 'https://awesome-hd.me/torrents.php?torrentid=%s',
+        'search': 'https://awesome-hd.me/searchapi.php?action=imdbsearch&passkey=%s&imdb=%s&internal=%s',
+        'download': 'https://awesome-hd.me/torrents.php?action=download&id=%s&authkey=%s&torrent_pass=%s',
     }
     http_time_between_calls = 1
 


### PR DESCRIPTION
Awesome-HD has changed from awesome-hd.net to awesome-hd.me This change updates the url so that CP can correctly search AHD again.

awesome-hd.net currently redirects to awesome-hd.me as well, though it doesn't appear to be a redirect that CP can follow correctly.