### PR TITLE
Vuze Remote Support - Get X-Transmission-Session-Id from headers

### DIFF
--- a/couchpotato/core/downloaders/transmission.py
+++ b/couchpotato/core/downloaders/transmission.py
@@ -237,7 +237,7 @@ class TransmissionRPC(object):
                 msg = str(err.read())
                 try:
                     self.session_id = \
-                        re.search('X-Transmission-Session-Id:\s*(\w+)', msg).group(1)
+                        err.hdrs['X-Transmission-Session-Id']
                     log.debug('X-Transmission-Session-Id: %s', self.session_id)
 
                     # #resend request with the updated header


### PR DESCRIPTION
**Reason**

This modification allows using Vuze Remote (Azureus) by configuring it as Transmission downloader in CouchPotato.

Vuze Remote json-rpc protocol is compatible with the one of Transmission, but there is a small difference with the HTTP Error 409 message that it returns when CouchPotato uses wrong (or none-initially) session ID. Transmission returns proper session ID inside the error message and the headers. Vuze Remote provides the session ID only in the headers of returned packet. Before the modification, the error message was scanned for new ID. After the modification the new session ID is acquired from the headers, so both Transmission and Vuze Remote works.

**What was done**

Changed the method of refreshing X-Transmission-Session-Id, when the one provided for connection is mismatched and HTTP Error 409 occurs.

When HTTP Error occurs,  _urllib2.urlopen_ throws an exception, so we cannot use the return value to read headers. Apparently there is an undocumented _hdrs_ element of _HTTPError_ object that we can use to read headers. That is used in the modification.
