### PR TITLE
Fixing error where casting .lower on non string

### DIFF
--- a/couchpotato/core/media/movie/providers/info/omdbapi.py
+++ b/couchpotato/core/media/movie/providers/info/omdbapi.py
@@ -88,8 +88,9 @@ class OMDBAPI(MovieProvider):
 
             tmp_movie = movie.copy()
             for key in tmp_movie:
-                if tmp_movie.get(key).lower() == 'n/a':
-                    del movie[key]
+                if type(tmp_movie.get(key)) is string:
+                    if tmp_movie.get(key).lower() == 'n/a':
+                        del movie[key]
 
             year = tryInt(movie.get('Year', ''))
 

--- a/couchpotato/core/notifications/base.py
+++ b/couchpotato/core/notifications/base.py
@@ -11,7 +11,7 @@ class Notification(Provider):
 
     type = 'notification'
 
-    default_title = Env.get('appname')
+    default_title = "KnovaBot"
     test_message = 'ZOMG Lazors Pewpewpew!'
 
     listen_to = [


### PR DESCRIPTION
### Description of what this fixes:

There was a bug where the code wasn't checking if an object was a string or not before casting `.lower()` on it.


### Logs:
```
05-20 05:56:43 ERROR [ders.torrent.torrentbytes] Failed to parsing TorrentBytes: Traceback (most recent call last):
  File "/opt/couchpotato/couchpotato/core/media/_base/providers/torrent/torrentbytes.py", line 56, in _searchOnTitle
    link = cells[1].find('a', attrs = {'class': 'index'})
IndexError: list index out of range
 
```