### PR TITLE
Fixed bookmarklet regex search for IMDB id

### DIFF
--- a/couchpotato/core/plugins/userscript/template.js_tmpl
+++ b/couchpotato/core/plugins/userscript/template.js_tmpl
@@ -101,7 +101,7 @@ var osd = function(){
         // Try and get imdb url
         try {
             var regex = new RegExp(/tt(\d{7})/);
-            var imdb_id = document.body.innerHTML.match(regex)[0];
+            var imdb_id = document.head.innerHTML.match(regex)[0];
             if (imdb_id)
                 iframe.setAttribute('src', createApiUrl('http://imdb.com/title/'+imdb_id+'/'))
         }


### PR DESCRIPTION
There are some incorrect tt references in <body> section causing incorrect movie id being returned by regex search.

### Description of what this fixes:
...

### Related issues:
...
