### PR TITLE
Brought down the Directory List pop up location

### DIFF
--- a/couchpotato/static/style/combined.min.css
+++ b/couchpotato/static/style/combined.min.css
@@ -984,7 +984,7 @@ input[type=text],textarea{-webkit-appearance:none}
 .page.settings .choice .select_wrapper select{min-width:0!important}
 .page.settings .renamer_to.renamer_to{-webkit-flex-flow:row wrap;-ms-flex-flow:row wrap;flex-flow:row wrap}
 .page.settings .renamer_to.renamer_to .ctrlHolder{width:100%}
-.directory_list{z-index:2;position:absolute;width:450px;margin:28px 0 20px;background:#ac0000;box-shadow:0 0 15px 2px rgba(0,0,0,.15);border-radius:3px 3px 0 0}
+.directory_list{z-index:2;position:absolute;top:60px;width:450px;margin:28px 0 20px;background:#ac0000;box-shadow:0 0 15px 2px rgba(0,0,0,.15);border-radius:3px 3px 0 0}
 .dark .directory_list{background:#f85c22;box-shadow:0 5px 15px 2px rgba(0,0,0,.4)}
 .directory_list .pointer{border-right:6px solid transparent;border-left:6px solid transparent;border-bottom:6px solid transparent;border-bottom-color:#ac0000;display:block;position:absolute;width:0;margin:-6px 0 0 100px}
 .dark .directory_list .pointer{border-bottom-color:#f85c22}


### PR DESCRIPTION
Updated class directory_list to bring down the pop up window to allow users to change directory when pop up is above expected location.

### Description of what this fixes:
... Fixes the Directory Pop up that gets pushed above viewer window

### Related issues:
... #[7153](https://github.com/CouchPotato/CouchPotatoServer/pull/7153)