### PR TITLE
updatet hepiratebay.py .. fix problematic proxies

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/thepiratebay.py
+++ b/couchpotato/core/media/_base/providers/torrent/thepiratebay.py
@@ -25,7 +25,6 @@ class Base(TorrentMagnetProvider):
     http_time_between_calls = 0
 
     proxy_list = [
-        'https://pirateproxy.cat',
         'https://pirateproxy.wf',
         'https://pirateproxy.tf',
         'https://urbanproxy.eu',
@@ -34,8 +33,6 @@ class Base(TorrentMagnetProvider):
         'https://thepiratebay.uk.net',
         'https://thebay.tv',
         'https://thepirateproxy.co',
-        'https://theproxypirate.pw',
-        'https://arrr.xyz',
         'https://tpb.dashitz.com'
     ]
 


### PR DESCRIPTION
i remove proxy's that give malware infected torrent or nonexistent ones .
       ( 'httpx://pirateproxy.cat',
        'httpx://theproxypirate.pw',
        'httpx://arrr.xyz',)

the first two redirect to pirateproxy.sh that show fake malware infected torrent.
example: 
https://pirateproxy.sh/torrent/20242390/Ant-Man_and_the_Wasp_2018_HDRip_XviD_AC3-EVO


the arrr.xyz give a Error 1016 Origin DNS error .

### Description of what this fixes:
...

### Related issues:
...
