### PR TITLE
prevent CouchPotato from running chmod on utorrent owned files

### DIFF
--- a/couchpotato/core/downloaders/utorrent.py
+++ b/couchpotato/core/downloaders/utorrent.py
@@ -181,8 +181,8 @@ class uTorrent(DownloaderBase):
                 elif torrent[4] == 1000:
                     status = 'completed'
 
-                if not status == 'busy':
-                    self.removeReadOnly(torrent_files)
+                # if not status == 'busy':
+                    # self.removeReadOnly(torrent_files)
 
                 release_downloads.append({
                     'id': torrent[0],


### PR DESCRIPTION
Prevent CouchPotato from running chmod on utorrent owned files.

When running CouchPotato and uTorrent as a service under different user accounts CouchPotato is not the owner of the files that uTorrent downloads and fails process downloads as it is trying to chmod them.  Disabling this process makes everything work again (been running with this changes for the past number of months without issue), but I'm not sure why it was attempting to this in the first place,