### PR TITLE
Fix 4K qualities + rarbg 4k support

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/rarbg.py
+++ b/couchpotato/core/media/_base/providers/torrent/rarbg.py
@@ -17,6 +17,10 @@ class Base(TorrentMagnetProvider):
         'token': 'https://torrentapi.org/pubapi_v2.php?get_token=get_token&app_id=couchpotato',
         'search': 'https://torrentapi.org/pubapi_v2.php?token=%s&mode=search&search_imdb=%s&min_seeders=%s&min_leechers'
                   '=%s&ranked=%s&category=movies&format=json_extended&app_id=couchpotato',
+        'search4k': 'https://torrentapi.org/pubapi_v2.php?token=%s&mode=search&search_imdb=%s&min_seeders=%s&min_leechers'
+                  '=%s&ranked=%s&category=51&format=json_extended&app_id=couchpotato',
+        'search4khdr': 'https://torrentapi.org/pubapi_v2.php?token=%s&mode=search&search_imdb=%s&min_seeders=%s&min_leechers'
+                  '=%s&ranked=%s&category=52&format=json_extended&app_id=couchpotato',
     }
 
     http_time_between_calls = 2  # Seconds
@@ -38,7 +42,14 @@ class Base(TorrentMagnetProvider):
         if (self._token != 0) and (movieyear == 0 or movieyear <= curryear):
             data = self.getJsonData(self.urls['search'] % (self._token, movieid, self.conf('min_seeders'),
                                                            self.conf('min_leechers'), self.conf('ranked_only')), headers = self.getRequestHeaders())
-
+            data4k = self.getJsonData(self.urls['search4k'] % (self._token, movieid, self.conf('min_seeders'),
+                                                           self.conf('min_leechers'), self.conf('ranked_only')), headers = self.getRequestHeaders())                                                           
+            data4khdr = self.getJsonData(self.urls['search4khdr'] % (self._token, movieid, self.conf('min_seeders'),
+                                                           self.conf('min_leechers'), self.conf('ranked_only')), headers = self.getRequestHeaders())                                                                                                        
+            if "torrent_results" in data4k:
+                data["torrent_results"] += (data4k["torrent_results"]) 
+            if "torrent_results" in data4khdr:
+                data["torrent_results"] += (data4khdr["torrent_results"]) 
             if data:
                 if 'error_code' in data:
                     if data['error'] == 'No results found':

--- a/couchpotato/core/plugins/quality/main.py
+++ b/couchpotato/core/plugins/quality/main.py
@@ -23,11 +23,11 @@ class QualityPlugin(Plugin):
     }
 
     qualities = [
-		{'identifier': '2160p', 'hd': True, 'allow_3d': True, 'size': (10000, 650000), 'median_size': 20000, 'label': '2160p', 'width': 3840, 'height': 2160, 'alternative': [], 'allow': [], 'ext':['mkv'], 'tags': ['x264', 'h264', '2160']},
+		{'identifier': '2160p', 'hd': True, 'allow_3d': True, 'size': (10000, 50000), 'median_size': 20000, 'label': '2160p', 'width': 3840, 'height': 2160, 'alternative': [], 'allow': [], 'ext':['mkv'], 'tags': ['h265', 'x265', '2160', '2160p', 'webdl', ('web', 'dl'), 'bluray']},
         {'identifier': 'bd50', 'hd': True, 'allow_3d': True, 'size': (20000, 60000), 'median_size': 40000, 'label': 'BR-Disk', 'alternative': ['bd25', ('br', 'disk')], 'allow': ['1080p'], 'ext':['iso', 'img'], 'tags': ['bdmv', 'certificate', ('complete', 'bluray'), 'avc', 'mvc']},
-        {'identifier': '1080p', 'hd': True, 'allow_3d': True, 'size': (4000, 20000), 'median_size': 10000, 'label': '1080p', 'width': 1920, 'height': 1080, 'alternative': [], 'allow': [], 'ext':['mkv', 'm2ts', 'ts'], 'tags': ['m2ts', 'x264', 'h264', '1080']},
+        {'identifier': '1080p', 'hd': True, 'allow_3d': True, 'size': (4000, 25000), 'median_size': 10000, 'label': '1080p', 'width': 1920, 'height': 1080, 'alternative': [], 'allow': [], 'ext':['mkv', 'm2ts', 'ts'], 'tags': ['m2ts', 'x264', 'h264', '1080', '1080p']},
         {'identifier': '720p', 'hd': True, 'allow_3d': True, 'size': (3000, 10000), 'median_size': 5500, 'label': '720p', 'width': 1280, 'height': 720, 'alternative': [], 'allow': [], 'ext':['mkv', 'ts'], 'tags': ['x264', 'h264', '720']},
-        {'identifier': 'brrip', 'hd': True, 'allow_3d': True, 'size': (700, 7000), 'median_size': 2000, 'label': 'BR-Rip', 'alternative': ['bdrip', ('br', 'rip'), 'hdtv', 'hdrip'], 'allow': ['720p', '1080p', '2160p'], 'ext':['mp4', 'avi'], 'tags': ['webdl', ('web', 'dl')]},
+        {'identifier': 'brrip', 'hd': True, 'allow_3d': True, 'size': (700, 7000), 'median_size': 2000, 'label': 'BR-Rip', 'alternative': ['bdrip', ('br', 'rip'), 'hdtv', 'hdrip'], 'allow': ['720p', '1080p'], 'ext':['mp4', 'avi'], 'tags': []},
         {'identifier': 'dvdr', 'size': (3000, 10000), 'median_size': 4500, 'label': 'DVD-R', 'alternative': ['br2dvd', ('dvd', 'r')], 'allow': [], 'ext':['iso', 'img', 'vob'], 'tags': ['pal', 'ntsc', 'video_ts', 'audio_ts', ('dvd', 'r'), 'dvd9']},
         {'identifier': 'dvdrip', 'size': (600, 2400), 'median_size': 1500, 'label': 'DVD-Rip', 'width': 720, 'alternative': [('dvd', 'rip')], 'allow': [], 'ext':['avi'], 'tags': [('dvd', 'rip'), ('dvd', 'xvid'), ('dvd', 'divx')]},
         {'identifier': 'scr', 'size': (600, 1600), 'median_size': 700, 'label': 'Screener', 'alternative': ['screener', 'dvdscr', 'ppvrip', 'dvdscreener', 'hdscr', 'webrip', ('web', 'rip')], 'allow': ['dvdr', 'dvdrip', '720p', '1080p'], 'ext':[], 'tags': []},


### PR DESCRIPTION
### Description of what this fixes:
This one fixes
* qualities scoring, before a lot movies could end up being marked as 2160p while they actually were 1080p, and some 2160p web-dl rips were not recognized as 2160p but brrip or totally ommitted
* fix rarbg as it has new categories for 4k and 4k hdr and releases present there are not always present in 'movies' category aswell

After those fixes my CP is accurate like never before

### Related issues:
...
