### PR TITLE
Fix YTS 7-Digit IMDB Searches

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -18,7 +18,7 @@ class Base(TorrentMagnetProvider):
     def _search(self, movie, quality, results):
         limit = 10
         page = 1
-        data = self.getJsonData(self.urls['search'] % (getIdentifier(movie), limit, page))
+        data = self.getJsonData(self.urls['search'] % (getIdentifier(movie).replace("tt0", "tt"), limit, page))
 
         if data:
             movie_count = tryInt(data['data']['movie_count'])


### PR DESCRIPTION
### Description of what this fixes:
YTS does not find older 7-digit films after the change in the previous update. This fixes that issue.

This will only replace tt0 with tt, thus not affecting the new 8-digit IMDB ids.