### PR TITLE
Fix YTS domain (.ag/.am -> .mx)

### DIFF
--- a/couchpotato/core/media/_base/providers/torrent/yts.py
+++ b/couchpotato/core/media/_base/providers/torrent/yts.py
@@ -9,10 +9,10 @@ log = CPLog(__name__)
 
 class Base(TorrentMagnetProvider):
     # Only qualities allowed: 720p/1080p/3D - the rest will fail.
-    # All YTS.ag torrents are verified
+    # All YTS.mx torrents are verified
     urls = {
-        'detail': 'https://yts.am/api#list_movies',
-        'search': 'https://yts.am/api/v2/list_movies.json?query_term=%s&limit=%s&page=%s'
+        'detail': 'https://yts.mx/api#list_movies',
+        'search': 'https://yts.mx/api/v2/list_movies.json?query_term=%s&limit=%s&page=%s'
     }
 
     def _search(self, movie, quality, results):
@@ -77,7 +77,7 @@ config = [{
             'tab': 'searcher',
             'list': 'torrent_providers',
             'name': 'YTS',
-            'description': '<a href="https://yts.ag/" target="_blank">YTS</a>',
+            'description': '<a href="https://yts.mx/" target="_blank">YTS</a>',
             'wizard': True,
             'icon': 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAACL0lEQVR4AS1SPW/UQBAd23fxne/Ld2dvzvHuzPocEBAKokCBqG'
                     'iQ6IgACYmvUKRBFEQgKKGg4BAlUoggggYUEQpSHOI7CIEoQs/fYcbLaU/efTvvvZlnA1qydoxU5kcxX0CkgmQZtPy0hCUjvK+W'


### PR DESCRIPTION
YTS no longer works because the domain has changed. This patch uses the new domain instead.
