### PR TITLE
Fix magnet links from Jackett

### DIFF
--- a/couchpotato/core/media/_base/providers/base.py
+++ b/couchpotato/core/media/_base/providers/base.py
@@ -203,6 +203,9 @@ class YarrProvider(Provider):
         return {}
 
     def download(self, url = '', nzb_id = ''):
+        if re.match('^magnet:.*$', url):
+            return url
+        
         try:
             return self.urlopen(url, headers = {'User-Agent': Env.getIdentifier()}, show_error = False)
         except:

--- a/couchpotato/core/media/_base/providers/torrent/torrentpotato.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentpotato.py
@@ -47,15 +47,9 @@ class Base(TorrentProvider):
                             req = requests.get(torrent.get('download_url'), allow_redirects = False)
                             if req.status_code == 302 and re.match('^magnet:.*$', req.headers["Location"]):
                                 torrent['download_url'] =  req.headers["Location"]
-                                proto = "torrent_magnet"
-                            else:
-                                proto = "transmission"
-                        else:
-                            proto = "torrent_magnet"
-                                
                         results.append({
                             'id': torrent.get('torrent_id'),
-                            'protocol' : proto,
+                            'protocol': 'torrent' if re.match('^(http|https|ftp)://.*$', torrent.get('download_url')) else 'torrent_magnet',
                             'provider_extra': urlparse(host['host']).hostname or host['host'],
                             'name': toUnicode(torrent.get('release_name')),
                             'url': torrent.get('download_url'),

--- a/couchpotato/core/media/_base/providers/torrent/torrentpotato.py
+++ b/couchpotato/core/media/_base/providers/torrent/torrentpotato.py
@@ -44,14 +44,14 @@ class Base(TorrentProvider):
                 elif torrents.get('results'):
                     for torrent in torrents.get('results', []):
                         if re.match('^(http|https|ftp)://.*$', torrent.get('download_url')):
-                             req = requests.get(torrent.get('download_url'), allow_redirects = False)
-                             if req.status_code == 302 and re.match('^magnet:.*$', req.headers["Location"]):
-                                 torrent['download_url'] =  req.headers["Location"]
-                                 proto = "torrent_magnet"
-                             else:
-                                 proto = "transmission"
-                         else:
-                             proto = "torrent_magnet"
+                            req = requests.get(torrent.get('download_url'), allow_redirects = False)
+                            if req.status_code == 302 and re.match('^magnet:.*$', req.headers["Location"]):
+                                torrent['download_url'] =  req.headers["Location"]
+                                proto = "torrent_magnet"
+                            else:
+                                proto = "transmission"
+                        else:
+                            proto = "torrent_magnet"
                                 
                         results.append({
                             'id': torrent.get('torrent_id'),


### PR DESCRIPTION
### Description of what this fixes:

1. Attempts to fix the "InvalidSchema: No connection adapters were found for" magnet links from Jackett.
2. Attempts to fix the issue of magnet links not being recognized due to being embedded in 302 redirected urls.

### Related issues:

https://github.com/Jackett/Jackett/issues/8788