### PR TITLE
Updated protocol from HTTP to HTTPS since IMDB returns 301 on HTTP

### DIFF
--- a/couchpotato/core/media/movie/providers/automation/imdb.py
+++ b/couchpotato/core/media/movie/providers/automation/imdb.py
@@ -99,12 +99,12 @@ class IMDBWatchlist(IMDBBase):
                 # Get list ID
                 ids = re.findall('(?:list/|list_id=)([a-zA-Z0-9\-_]{11})', watchlist_url)
                 if len(ids) == 1:
-                    watchlist_url = 'http://www.imdb.com/list/%s/?view=compact&sort=created:asc' % ids[0]
+                    watchlist_url = 'https://www.imdb.com/list/%s/?view=compact&sort=created:asc' % ids[0]
                 # Try find user id with watchlist
                 else:
                     userids = re.findall('(ur\d{7,9})', watchlist_url)
                     if len(userids) == 1:
-                        watchlist_url = 'http://www.imdb.com/user/%s/watchlist?view=compact&sort=created:asc' % userids[0]
+                        watchlist_url = 'https://www.imdb.com/user/%s/watchlist?view=compact&sort=created:asc' % userids[0]
             except:
                 log.error('Failed getting id from watchlist: %s', traceback.format_exc())
 


### PR DESCRIPTION
### Description of what this fixes:

Updated protocol from HTTP to HTTPS since IMDB returns 301 Moved Permanently on HTTP which causes CP to find no new movies.