### PR TITLE
fix(docs): corrects typo in contributing.md

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -14,7 +14,7 @@ Lastly, for anything related to CouchPotato, feel free to stop by the [forum](ht
 Issues are intended for reporting bugs and weird behaviour or suggesting improvements to CouchPotatoServer.
 Before you submit an issue, please go through the following checklist:
  * **FILL IN ALL THE FIELDS ASKED FOR**
- * **POST MORE THAN A SINGLE LINE LOG**, if you do, you'd better have a easy reproducable bug
+ * **POST MORE THAN A SINGLE LINE LOG**, if you do, you'd better have an easy reproducible bug
  * Search through existing issues (*including closed issues!*) first: you might be able to get your answer there.
  * Double check your issue manually, because it could be an external issue. 
  * Post logs with your issue: Without seeing what is going on, the developers can't reproduce the error.


### PR DESCRIPTION
### Description of what this fixes:
...
Scope of changes is restricted to docs only. Corrects typos in single line of contributing.md. Changes are in agreement with Standard American English.

a => an
reproducable => reproducible

### Related issues:
...